### PR TITLE
Enabled `wrap_help` feature for `clap`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["command-line-utilities"]
 exclude = [".github"]
 
 [dependencies]
-clap = { version = "4.0.22", features = ["derive"] }
+clap = { version = "4.0.22", features = ["derive", "wrap_help"] }
 colored = "2.0.0"
 itertools = "0.10.5"
 lazy_static = "1.4.0"


### PR DESCRIPTION
This makes the wrapping of some of the longer help descriptions look much nicer.

On that note: I would also suggest setting [`max_term_width`](https://docs.rs/clap/latest/clap/builder/struct.Command.html#method.max_term_width) to `72` to improve legibility.

45--90 chars/line is the suggested default for body text. I wish terminal apps paid more attention to this or there was an environment variable all CLI apps respected but alas. The good old 72 chars/line sits close to the middle of that so it's a good default.

If you like that idea I can open a PR for that too.