### PR TITLE
Add udev iManufacturer/iProduct/iSerial support to linux

### DIFF
--- a/examples/extra_data.rs
+++ b/examples/extra_data.rs
@@ -2,9 +2,8 @@ use cyme::lsusb::profiler;
 
 fn main() -> Result<(), String> {
     // get all system devices - this time with extra data which contain the USBConfiguration, driver data (with udev)
-    let sp_usb = profiler::get_spusb_with_extra(false).map_err(|e| {
-        format!("Failed to gather system USB data from libusb, Error({})", e)
-    })?;
+    let sp_usb = profiler::get_spusb_with_extra(false)
+        .map_err(|e| format!("Failed to gather system USB data from libusb, Error({})", e))?;
 
     let devices = sp_usb.flatten_devices();
 
@@ -14,7 +13,7 @@ fn main() -> Result<(), String> {
             println!("Device {} has configurations:", device.name);
             for c in extra.configurations.iter() {
                 println!("{:?}", c);
-            };
+            }
         });
     }
 

--- a/examples/filter_devices.rs
+++ b/examples/filter_devices.rs
@@ -2,14 +2,13 @@
 ///
 /// See [`USBFilter`] docs for more information
 use cyme::lsusb::profiler;
-use cyme::usb::ClassCode;
 use cyme::system_profiler::USBFilter;
+use cyme::usb::ClassCode;
 
 fn main() -> Result<(), String> {
     // get all system devices
-    let mut sp_usb = profiler::get_spusb(false).map_err(|e| {
-        format!("Failed to gather system USB data from libusb, Error({})", e)
-    })?;
+    let mut sp_usb = profiler::get_spusb(false)
+        .map_err(|e| format!("Failed to gather system USB data from libusb, Error({})", e))?;
 
     // if one does want the tree, use the utility
     let filter = USBFilter {
@@ -19,7 +18,9 @@ fn main() -> Result<(), String> {
 
     // will retain only the buses that have devices that match the filter - parent devices such as hubs with a HID device will be retained
     filter.retain_buses(&mut sp_usb.buses);
-    sp_usb.buses.retain(|b| b.devices.as_ref().map_or(false, |d| d.is_empty()));
+    sp_usb
+        .buses
+        .retain(|b| b.devices.as_ref().map_or(false, |d| d.is_empty()));
 
     // if one does not care about the tree, flatten the devices and do manually
     // let hid_devices = sp_usb.flatten_devices().iter().filter(|d| d.class == Some(ClassCode::HID));

--- a/examples/print_devices.rs
+++ b/examples/print_devices.rs
@@ -1,11 +1,10 @@
-use cyme::lsusb::profiler;
 use cyme::display;
+use cyme::lsusb::profiler;
 
 fn main() -> Result<(), String> {
     // get all system devices - use get_spusb_with_extra for verbose info
-    let sp_usb = profiler::get_spusb(false).map_err(|e| {
-        format!("Failed to gather system USB data from libusb, Error({})", e)
-    })?;
+    let sp_usb = profiler::get_spusb(false)
+        .map_err(|e| format!("Failed to gather system USB data from libusb, Error({})", e))?;
 
     // flatten since we don't care tree/buses
     let devices = sp_usb.flatten_devices();

--- a/examples/walk_sp_data.rs
+++ b/examples/walk_sp_data.rs
@@ -13,9 +13,8 @@ fn recusive_map_devices(device: &USBDevice) {
 
 fn main() -> Result<(), String> {
     // get all system devices
-    let sp_usb = profiler::get_spusb(false).map_err(|e| {
-        format!("Failed to gather system USB data from libusb, Error({})", e)
-    })?;
+    let sp_usb = profiler::get_spusb(false)
+        .map_err(|e| format!("Failed to gather system USB data from libusb, Error({})", e))?;
 
     // SPUSBDataType contains buses...
     for bus in sp_usb.buses {

--- a/src/colour.rs
+++ b/src/colour.rs
@@ -196,9 +196,7 @@ where
     match ColorOrNull::deserialize(deserializer)? {
         ColorOrNull::Str(s) => match s {
             "" => Ok(None),
-            _ => Color::try_from(s)
-                .map(Some)
-                .map_err(serde::de::Error::custom),
+            _ => Ok(Some(Color::from(s))),
         },
         ColorOrNull::FromStr(i) => Ok(Some(i)),
         ColorOrNull::Null => Ok(None),
@@ -222,8 +220,7 @@ where
         where
             E: serde::de::Error,
         {
-            Color::try_from(value)
-                .map_err(|_| E::invalid_value(serde::de::Unexpected::Str(value), &self))
+            Ok(Color::from(value))
         }
 
         fn visit_seq<M>(self, mut seq: M) -> Result<Color, M::Error>

--- a/src/display.rs
+++ b/src/display.rs
@@ -612,9 +612,7 @@ impl Block<DeviceBlocks, USBDevice> for DeviceBlocks {
         }
     }
 
-    fn generate_padding(
-        d: &[&system_profiler::USBDevice],
-    ) -> HashMap<Self, usize> {
+    fn generate_padding(d: &[&system_profiler::USBDevice]) -> HashMap<Self, usize> {
         DeviceBlocks::iter()
             .map(|b| (b, cmp::max(b.heading().len(), b.len(d))))
             .collect()
@@ -871,9 +869,7 @@ impl Block<BusBlocks, USBBus> for BusBlocks {
         }
     }
 
-    fn generate_padding(
-        d: &[&USBBus],
-    ) -> HashMap<Self, usize> {
+    fn generate_padding(d: &[&USBBus]) -> HashMap<Self, usize> {
         BusBlocks::iter()
             .map(|b| (b, cmp::max(b.heading().len(), b.len(d))))
             .collect()
@@ -1004,9 +1000,7 @@ impl Block<ConfigurationBlocks, USBConfiguration> for ConfigurationBlocks {
         }
     }
 
-    fn generate_padding(
-        d: &[&USBConfiguration],
-    ) -> HashMap<Self, usize> {
+    fn generate_padding(d: &[&USBConfiguration]) -> HashMap<Self, usize> {
         ConfigurationBlocks::iter()
             .map(|b| (b, cmp::max(b.heading().len(), b.len(d))))
             .collect()
@@ -1401,10 +1395,7 @@ pub enum Sort {
 
 impl Sort {
     /// The clone and sort the [`USBDevice`]s `d`
-    pub fn sort_devices(
-        &self,
-        d: &Vec<USBDevice>,
-    ) -> Vec<USBDevice> {
+    pub fn sort_devices(&self, d: &Vec<USBDevice>) -> Vec<USBDevice> {
         let mut sorted = d.to_owned();
         match self {
             Sort::BranchPosition => sorted.sort_by_key(|d| d.get_branch_position()),
@@ -1416,10 +1407,7 @@ impl Sort {
     }
 
     /// The clone and sort the references to [`USBDevice`]s `d`
-    pub fn sort_devices_ref<'a>(
-        &self,
-        d: &Vec<&'a USBDevice>,
-    ) -> Vec<&'a USBDevice> {
+    pub fn sort_devices_ref<'a>(&self, d: &Vec<&'a USBDevice>) -> Vec<&'a USBDevice> {
         let mut sorted = d.to_owned();
         match self {
             Sort::BranchPosition => sorted.sort_by_key(|d| d.get_branch_position()),
@@ -1812,10 +1800,7 @@ fn generate_extra_blocks(
 }
 
 /// Print `devices` `USBDevice` references without looking down each device's devices!
-pub fn print_flattened_devices(
-    devices: &Vec<&USBDevice>,
-    settings: &PrintSettings,
-) {
+pub fn print_flattened_devices(devices: &Vec<&USBDevice>, settings: &PrintSettings) {
     let mut db = settings
         .device_blocks
         .to_owned()
@@ -1908,15 +1893,13 @@ pub fn print_flattened_devices(
 /// A way of printing a reference flattened `SPUSBDataType` rather than hard flatten
 ///
 /// Prints each `&USBBus` and tuple pair `Vec<&USBDevice>`
-pub fn print_bus_grouped(
-    bus_devices: Vec<(&USBBus, Vec<&USBDevice>)>,
-    settings: &PrintSettings,
-) {
-    let bb = settings.bus_blocks.to_owned().unwrap_or(
-        Block::<BusBlocks, USBBus>::default_blocks(
+pub fn print_bus_grouped(bus_devices: Vec<(&USBBus, Vec<&USBDevice>)>, settings: &PrintSettings) {
+    let bb = settings
+        .bus_blocks
+        .to_owned()
+        .unwrap_or(Block::<BusBlocks, USBBus>::default_blocks(
             settings.verbosity >= MAX_VERBOSITY || settings.more,
-        ),
-    );
+        ));
     let mut pad: HashMap<BusBlocks, usize> = if !settings.no_padding {
         let buses: Vec<&USBBus> = bus_devices.iter().map(|bd| bd.0).collect();
         BusBlocks::generate_padding(&buses)
@@ -2067,8 +2050,7 @@ pub fn print_endpoints(
 
             // maybe should just do once at start of bus
             if settings.headings && i == 0 {
-                let heading =
-                    render_heading(blocks, &pad, max_variable_string_len).join(" ");
+                let heading = render_heading(blocks, &pad, max_variable_string_len).join(" ");
                 println!("{}  {}", prefix, heading.bold().underline());
             }
 
@@ -2080,8 +2062,7 @@ pub fn print_endpoints(
             );
         } else {
             if settings.headings && i == 0 {
-                let heading =
-                    render_heading(blocks, &pad, max_variable_string_len).join(" ");
+                let heading = render_heading(blocks, &pad, max_variable_string_len).join(" ");
                 println!("{:spaces$}{}", "", heading.bold().underline(), spaces = 6);
             }
 
@@ -2181,8 +2162,7 @@ pub fn print_interfaces(
 
             // maybe should just do once at start of bus
             if settings.headings && i == 0 {
-                let heading =
-                    render_heading(blocks.0, &pad, max_variable_string_len).join(" ");
+                let heading = render_heading(blocks.0, &pad, max_variable_string_len).join(" ");
                 println!("{}  {}", prefix, heading.bold().underline());
             }
 
@@ -2196,8 +2176,7 @@ pub fn print_interfaces(
             );
         } else {
             if settings.headings && i == 0 {
-                let heading =
-                    render_heading(blocks.0, &pad, max_variable_string_len).join(" ");
+                let heading = render_heading(blocks.0, &pad, max_variable_string_len).join(" ");
                 println!("{:spaces$}{}", "", heading.bold().underline(), spaces = 4);
             }
 
@@ -2312,8 +2291,7 @@ pub fn print_configurations(
 
             // maybe should just do once at start of bus
             if settings.headings && i == 0 {
-                let heading =
-                    render_heading(blocks.0, &pad, max_variable_string_len).join(" ");
+                let heading = render_heading(blocks.0, &pad, max_variable_string_len).join(" ");
                 println!("{}  {}", prefix, heading.bold().underline());
             }
 
@@ -2326,8 +2304,7 @@ pub fn print_configurations(
             );
         } else {
             if settings.headings && i == 0 {
-                let heading =
-                    render_heading(blocks.0, &pad, max_variable_string_len).join(" ");
+                let heading = render_heading(blocks.0, &pad, max_variable_string_len).join(" ");
                 println!("{:spaces$}{}", "", heading.bold().underline(), spaces = 2);
             }
 
@@ -2487,12 +2464,13 @@ pub fn print_devices(
 
 /// Print SPUSBDataType
 pub fn print_sp_usb(sp_usb: &SPUSBDataType, settings: &PrintSettings) {
-    let mut bb = settings.bus_blocks.to_owned().unwrap_or(Block::<
-        BusBlocks,
-        USBBus,
-    >::default_blocks(
-        settings.verbosity >= MAX_VERBOSITY || settings.more,
-    ));
+    let mut bb =
+        settings
+            .bus_blocks
+            .to_owned()
+            .unwrap_or(Block::<BusBlocks, USBBus>::default_blocks(
+                settings.verbosity >= MAX_VERBOSITY || settings.more,
+            ));
     let mut db = settings.device_blocks.to_owned().unwrap_or(
         if settings.verbosity >= MAX_VERBOSITY || settings.more {
             DeviceBlocks::default_blocks(true)
@@ -2590,8 +2568,7 @@ pub fn print_sp_usb(sp_usb: &SPUSBDataType, settings: &PrintSettings) {
             }
 
             if settings.headings {
-                let heading =
-                    render_heading(&bb, &pad, max_variable_string_len).join(" ");
+                let heading = render_heading(&bb, &pad, max_variable_string_len).join(" ");
                 // 2 spaces for bus start icon and space to info
                 println!("{:>spaces$}{}", "", heading.bold().underline(), spaces = 2);
             }
@@ -2646,18 +2623,15 @@ pub fn mask_serial(device: &mut USBDevice, hide: &MaskSerial, recursive: bool) {
     }
 
     if recursive {
-        device.devices.iter_mut().for_each(|dd| {
-            dd.iter_mut().for_each(|d| mask_serial(d, hide, recursive))
-        });
+        device
+            .devices
+            .iter_mut()
+            .for_each(|dd| dd.iter_mut().for_each(|d| mask_serial(d, hide, recursive)));
     }
 }
 
 /// Main cyme bin prepare for printing function - changes mutable `sp_usb` with requested `filter` and sort in `settings`
-pub fn prepare(
-    sp_usb: &mut SPUSBDataType,
-    filter: Option<USBFilter>,
-    settings: &PrintSettings,
-) {
+pub fn prepare(sp_usb: &mut SPUSBDataType, filter: Option<USBFilter>, settings: &PrintSettings) {
     // if not printing tree, hard flatten now before filtering as filter will retain non-matching parents with matching devices in tree
     // but only do it if there is a filter, grouping by bus (which uses tree print without tree...) or json
     // flattening now will also mean hubs will be removed when listing if `hide_hubs` because they will appear empty

--- a/src/lsusb.rs
+++ b/src/lsusb.rs
@@ -316,6 +316,7 @@ pub mod profiler {
             ),
             driver: None,
             syspath: None,
+            // These are idProduct, idVendor in lsusb - from usb_ids
             vendor: usb_ids::Vendor::from_id(device_desc.vendor_id()).map(|v| v.name().to_owned()),
             product_name: usb_ids::Device::from_vid_pid(
                 device_desc.vendor_id(),
@@ -414,7 +415,7 @@ pub mod profiler {
             .or({
                 #[cfg(all(target_os = "linux", feature = "udev"))]
                 {
-                    udev::get_udev_attribute(&sp_device.port_path(), "manufacturer")
+                    udev::get_udev_attribute(&sp_device.sysfs_name(), "manufacturer")
                 }
 
                 #[cfg(not(all(target_os = "linux", feature = "udev")))]
@@ -428,7 +429,7 @@ pub mod profiler {
         sp_device.name = match get_product_string(&device_desc, &mut usb_device).or({
             #[cfg(all(target_os = "linux", feature = "udev"))]
             {
-                udev::get_udev_attribute(&sp_device.port_path(), "product")
+                udev::get_udev_attribute(&sp_device.sysfs_name(), "product")
             }
 
             #[cfg(not(all(target_os = "linux", feature = "udev")))]
@@ -451,7 +452,7 @@ pub mod profiler {
         sp_device.serial_num = get_serial_string(&device_desc, &mut usb_device).or({
             #[cfg(all(target_os = "linux", feature = "udev"))]
             {
-                udev::get_udev_attribute(&sp_device.port_path(), "serial")
+                udev::get_udev_attribute(&sp_device.sysfs_name(), "serial")
             }
 
             #[cfg(not(all(target_os = "linux", feature = "udev")))]

--- a/src/lsusb.rs
+++ b/src/lsusb.rs
@@ -67,10 +67,7 @@ pub mod profiler {
             Some(s) => match s.parse::<u8>() {
                 Ok(v) => {
                     // Determine iConfiguration
-                    match get_sysfs_string(sysfs_name, "configuration") {
-                        Some(s) => Some((v, s)),
-                        None => None,
-                    }
+                    get_sysfs_string(sysfs_name, "configuration").map(|s| (v, s))
                 }
                 Err(_) => None,
             },
@@ -270,7 +267,7 @@ pub mod profiler {
                 let mut _interface = usb::USBInterface {
                     name: get_sysfs_string(&path, "interface")
                         .or(get_interface_string(&interface_desc, handle))
-                        .unwrap_or(String::new()),
+                        .unwrap_or_default(),
                     string_index: interface_desc.description_string_index().unwrap_or(0),
                     number: interface_desc.interface_number(),
                     path,

--- a/src/main.rs
+++ b/src/main.rs
@@ -437,8 +437,9 @@ fn cyme() -> Result<()> {
     };
 
     // add any config ENV override
-    config.print_non_critical_profiler_stderr = std::env::var_os("CYME_PRINT_NON_CRITICAL_PROFILER_STDERR")
-        .map_or(config.print_non_critical_profiler_stderr, |_| true);
+    config.print_non_critical_profiler_stderr =
+        std::env::var_os("CYME_PRINT_NON_CRITICAL_PROFILER_STDERR")
+            .map_or(config.print_non_critical_profiler_stderr, |_| true);
 
     merge_config(&config, &mut args);
 

--- a/src/system_profiler.rs
+++ b/src/system_profiler.rs
@@ -199,7 +199,7 @@ impl USBBus {
 
     /// syspath style path to bus
     pub fn path(&self) -> String {
-        get_trunk_path(self.get_bus_number(), &vec![])
+        get_trunk_path(self.get_bus_number(), &[])
     }
 
     /// sysfs style path to bus interface

--- a/src/system_profiler.rs
+++ b/src/system_profiler.rs
@@ -494,6 +494,11 @@ impl DeviceLocation {
     pub fn trunk_path(&self) -> String {
         get_trunk_path(self.bus, &self.tree_positions)
     }
+
+    /// Linux sysfs name of [`USBDevice`] similar to `port_path` but root_hubs use the USB controller name instead of port
+    pub fn sysfs_name(&self) -> String {
+        get_sysfs_name(self.bus, &self.tree_positions)
+    }
 }
 
 impl<'de> Deserialize<'de> for DeviceLocation {
@@ -941,6 +946,11 @@ impl USBDevice {
     /// Linux devpath to [`USBDevice`]
     pub fn dev_path(&self) -> String {
         get_dev_path(self.location_id.bus, Some(self.location_id.number))
+    }
+
+    /// Linux sysfs name of [`USBDevice`]
+    pub fn sysfs_name(&self) -> String {
+        self.location_id.sysfs_name()
     }
 
     /// Trunk device is first in tree

--- a/src/udev.rs
+++ b/src/udev.rs
@@ -49,6 +49,9 @@ pub fn get_udev_info(
 /// This only works on Linux and not all devices have all attributes.
 /// These attributes are generally readable by all users.
 ///
+/// NOTE: In general you should read from sysfs directly as it does not
+///       depend on the udev feature. See `get_sysfs_string()` in lsusb.rs
+///
 /// ```no_run
 /// use cyme::udev::get_udev_attribute;
 ///
@@ -78,7 +81,9 @@ pub fn get_udev_attribute<T: AsRef<std::ffi::OsStr> + std::fmt::Display>(
         }
     };
 
-    device.attribute_value(attribute).map(|s| s.to_str().unwrap_or("").to_string())
+    device
+        .attribute_value(attribute)
+        .map(|s| s.to_str().unwrap_or("").to_string())
 }
 
 #[cfg(test)]
@@ -101,7 +106,8 @@ mod tests {
     #[cfg_attr(not(feature = "usb_test"), ignore)]
     #[test]
     fn test_udev_attribute() {
-        let interface_class = get_udev_attribute(&String::from("1-0:1.0"),"bInterfaceClass").unwrap();
+        let interface_class =
+            get_udev_attribute(&String::from("1-0:1.0"), "bInterfaceClass").unwrap();
         assert_eq!(interface_class, "09");
     }
 }

--- a/src/udev.rs
+++ b/src/udev.rs
@@ -77,8 +77,8 @@ pub fn get_udev_attribute<T: AsRef<std::ffi::OsStr> + std::fmt::Display>(
             return None;
         }
     };
-    let value = device.attribute_value(attribute).unwrap_or_default();
-    Some(value.to_str().unwrap_or("").to_string())
+
+    device.attribute_value(attribute).map(|s| s.to_str().unwrap_or("").to_string())
 }
 
 #[cfg(test)]

--- a/src/udev.rs
+++ b/src/udev.rs
@@ -6,7 +6,7 @@ use crate::error::{Error, ErrorKind};
 
 /// Get and assign `driver_ref` the driver and `syspath_ref` the syspath for device at the `port_path`
 ///
-/// The struct memebers are supplied as references to allow macro attributes calling this only on Linux with udev feature
+/// The struct members are supplied as references to allow macro attributes calling this only on Linux with udev feature
 ///
 /// ```no_run
 /// use cyme::udev::get_udev_info;
@@ -44,6 +44,43 @@ pub fn get_udev_info(
     Ok(())
 }
 
+/// Lookup a udev attribute given the `port_path` and `attribute`.
+///
+/// This only works on Linux and not all devices have all attributes.
+/// These attributes are generally readable by all users.
+///
+/// ```no_run
+/// use cyme::udev::get_udev_attribute;
+///
+/// let interface_class = get_udev_attribute(&String::from("1-0:1.0"),"bInterfaceClass").unwrap();
+/// assert_eq!(interface_class, "09");
+/// ```
+pub fn get_udev_attribute<T: AsRef<std::ffi::OsStr> + std::fmt::Display>(
+    port_path: &String,
+    attribute: T,
+) -> Option<String> {
+    let path: String = format!("/sys/bus/usb/devices/{}", port_path);
+    let device = match udevlib::Device::from_syspath(&Path::new(&path)).map_err(|e| {
+        Error::new(
+            ErrorKind::Udev,
+            &format!(
+                "Failed to get udev attribute {} for device at {}: Error({})",
+                attribute,
+                path,
+                e.to_string()
+            ),
+        )
+    }) {
+        Ok(d) => d,
+        Err(err) => {
+            log::warn!("{:?}", err);
+            return None;
+        }
+    };
+    let value = device.attribute_value(attribute).unwrap_or_default();
+    Some(value.to_str().unwrap_or("").to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -58,5 +95,13 @@ mod tests {
         get_udev_info(&mut driver, &mut syspath, &String::from("1-0:1.0")).unwrap();
         assert_eq!(driver, Some("hub".into()));
         assert_eq!(syspath.unwrap().contains("usb1/1-0:1.0"), true);
+    }
+
+    /// Tests can lookup bInterfaceClass of the root hub, which is always 09
+    #[cfg_attr(not(feature = "usb_test"), ignore)]
+    #[test]
+    fn test_udev_attribute() {
+        let interface_class = get_udev_attribute(&String::from("1-0:1.0"),"bInterfaceClass").unwrap();
+        assert_eq!(interface_class, "09");
     }
 }

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -628,7 +628,7 @@ pub struct USBInterface {
 
 impl USBInterface {
     /// Linux syspath to interface
-    pub fn path(&self, bus: u8, ports: &Vec<u8>, config: u8) -> String {
+    pub fn path(&self, bus: u8, ports: &[u8], config: u8) -> String {
         get_interface_path(bus, ports, config, self.number)
     }
 }
@@ -731,7 +731,7 @@ pub fn get_parent_path(bus: u8, ports: &[u8]) -> error::Result<String> {
             "Cannot get parent path for root device",
         ))
     } else {
-        Ok(get_port_path(bus, &ports[..ports.len() - 1].to_vec()))
+        Ok(get_port_path(bus, &ports[..ports.len() - 1]))
     }
 }
 
@@ -804,7 +804,7 @@ pub fn get_sysfs_name(bus: u8, ports: &[u8]) -> String {
         // special cae for root_hub
         format!("usb{}", bus)
     } else {
-        get_port_path(bus, &ports)
+        get_port_path(bus, ports)
     }
 }
 


### PR DESCRIPTION
- `cargo fmt --all`
- Fixes https://github.com/tuna-f1sh/cyme/issues/13
- Always prefers reading descriptors directly if possible (then udev,
  then usb id database)
- Requires udev feature

I don't really like how the `cfg`'s turned out, but it is fairly clear.
It would be nice to see if there are equivalents on Windows and macOS (I haven't investigated yet). I may dig around on Windows later to see what I come up with (or if it's even possible).