### PR TITLE
Name regex pattern icon type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +262,7 @@ dependencies = [
  "lazy_static",
  "log",
  "rand",
+ "regex",
  "rusb",
  "serde",
  "serde_json",
@@ -761,6 +771,35 @@ dependencies = [
  "libredox",
  "thiserror",
 ]
+
+[[package]]
+name = "regex"
+version = "1.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "roff"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ rand = "0.8.5"
 terminal_size = "0.2.5"
 strum = "0.24.1"
 strum_macros = "0.24.3"
+regex = "1.10.5"
 
 [dev-dependencies]
 diff = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ rand = "0.8.5"
 terminal_size = "0.2.5"
 strum = "0.24.1"
 strum_macros = "0.24.3"
-regex = "1.10.5"
+regex = { version = "1.10.5", optional = true }
 
 [dev-dependencies]
 diff = "0.1"
@@ -59,8 +59,9 @@ udev_hwdb = ["libusb", "udevlib?/hwdb"]
 # libudev C binding
 udevlib = ["libusb", "dep:udevlib"]
 usb_test = []
+regex_icon = ["dep:regex"]
 cli_generate = ["dep:clap_complete", "dep:clap_mangen"] # for generating man and completions
-default = ["libusb", "udev"]
+default = ["libusb", "udev", "regex_icon"]
 
 [[bin]]
 name = "cyme"

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ One can also be supplied with `--config`. Copy or refer to './doc/cyme\_example\
 
 See './doc/cyme\_example\_config.json' for an example of how icons can be defined and also the [docs](https://docs.rs/cyme/latest/cyme/icon/enum.Icon.html). The config can exclude the "user"/"colours" keys if one wishes not to define any new icons/colours.
 
-Icons are looked up in an order of User -> Default. For devices: `VidPid` -> `VidPidMsb` -> `Vid` -> `UnknownVendor` -> `get_default_vidpid_icon`, classes: `ClassifierSubProtocol` -> `Classifier` -> `UndefinedClassifier` -> `get_default_classifier_icon`. User supplied colours override all internal; if a key is missing, it will be `None`.
+Icons are looked up in an order of User -> Default. For devices: `Name` -> `VidPid` -> `VidPidMsb` -> `Vid` -> `UnknownVendor` -> `get_default_vidpid_icon`, classes: `ClassifierSubProtocol` -> `Classifier` -> `UndefinedClassifier` -> `get_default_classifier_icon`. User supplied colours override all internal; if a key is missing, it will be `None`.
 
 #### Icons not Showing/Boxes with Question Marks
 

--- a/doc/cyme_example_config.json
+++ b/doc/cyme_example_config.json
@@ -3,6 +3,7 @@
     "user": {
       "classifier#02": "",
       "classifier-sub-protocol#fe:01:01": "",
+      "name#.*sd\\scard\\sreader.*": "",
       "undefined-classifier": "☶",
       "unknown-vendor": "",
       "vid#05ac": "",

--- a/doc/cyme_example_config.json
+++ b/doc/cyme_example_config.json
@@ -3,7 +3,7 @@
     "user": {
       "classifier#02": "",
       "classifier-sub-protocol#fe:01:01": "",
-      "name#.*sd\\scard\\sreader.*": "",
+      "name#.*^[sS][dD]\\s[cC]ard\\s[rR]eader.*": "",
       "undefined-classifier": "☶",
       "unknown-vendor": "",
       "vid#05ac": "",

--- a/src/config.rs
+++ b/src/config.rs
@@ -154,6 +154,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg(feature = "regex_icon")]
     fn test_deserialize_example_file() {
         let path = PathBuf::from("./doc").join("cyme_example_config.json");
         assert!(Config::from_file(path).is_ok());

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -276,7 +276,7 @@ lazy_static! {
             (Icon::Vid(0x1fc9), "\u{f2db}"), // nxp 
             (Icon::Vid(0x1050), "\u{f084}"), // yubikey 
             (Icon::Vid(0x0781), "\u{f129e}"), // sandisk 󱊞
-            (Icon::Name(r".*sd\scard\sreader.*".to_string()), "\u{ef61}"), // sd card reader 
+            (Icon::Name(r".*^[sS][dD]\s[cC]ard\s[rR]eader.*".to_string()), "\u{ef61}"), // sd card reader 
             (Icon::VidPid((0x18D1, 0x2D05)), "\u{e70e}"), // android dev 
             (Icon::VidPid((0x18D1, 0xd00d)), "\u{e70e}"), // android 
             (Icon::VidPid((0x1d50, 0x606f)), "\u{f191d}"), // candlelight_fw gs_can 󱤝
@@ -445,7 +445,7 @@ impl IconTheme {
             .iter()
             .find(|(k, _)| {
                 if let Icon::Name(s) = k {
-                    regex::Regex::new(s).map_or(false, |r| r.is_match(&name.to_lowercase()))
+                    regex::Regex::new(s).map_or(false, |r| r.is_match(name))
                 } else {
                     false
                 }
@@ -462,7 +462,7 @@ impl IconTheme {
                 .iter()
                 .find(|(k, _)| {
                     if let Icon::Name(s) = k {
-                        regex::Regex::new(s).map_or(false, |r| r.is_match(&name.to_lowercase()))
+                        regex::Regex::new(s).map_or(false, |r| r.is_match(name))
                     } else {
                         false
                     }
@@ -511,7 +511,7 @@ pub fn example() -> HashMap<Icon, String> {
         ), // serial 
         (Icon::UndefinedClassifier, "\u{2636}".into()), //☶
         (
-            Icon::Name(r".*sd\scard\sreader.*".to_string()),
+            Icon::Name(r".*^[sS][dD]\s[cC]ard\s[rR]eader.*".to_string()),
             "\u{ef61}".into(),
         ), // sd card reader 
     ])
@@ -622,8 +622,11 @@ mod tests {
         let icon = Icon::from_str(str);
         assert_eq!(icon.unwrap(), Icon::Name("test".to_string()));
 
-        let str = r"name#sd\s+card";
+        let str = r"name#.*^[sS][dD]\s[cC]ard\s[rR]eader.*";
         let icon = Icon::from_str(str);
-        assert_eq!(icon.unwrap(), Icon::Name("sd\\s+card".to_string()));
+        assert_eq!(
+            icon.unwrap(),
+            Icon::Name(r".*^[sS][dD]\s[cC]ard\s[rR]eader.*".to_string())
+        );
     }
 }


### PR DESCRIPTION
Icon lookup based on Regex pattern match of device name. Useful for common devices with no common VIDPID like SD Card Reader included in DEFAULT_ICONS as part of this.

* Instatiating the `regex` for each lookup of the `Name` type isn’t ideal. `Name` could wrap `regex` not `String` but would require removing some derives and adding lifetime.
* Need to performance test to see what kind of overhead this adds for icon matching.