### PR TITLE
Update Cargo.toml for cargo-deb fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ pre-build = ["apt-get update && apt-get install --assume-yes libusb-1.0-0-dev li
 
 [package.metadata.deb]
 section = "utility"
+copyright = "2024, John Whittington <john@jbrengineering.co.uk>"
 changelog = "CHANGELOG.md"
 extended-description = """\
 List system USB buses and devices; a lib and modern cross-platform 'lsusb' \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ pre-build = ["apt-get update && apt-get install --assume-yes libusb-1.0-0-dev li
 
 [package.metadata.deb]
 section = "utility"
-change-log = "CHANGELOG.md"
+changelog = "CHANGELOG.md"
 extended-description = """\
 List system USB buses and devices; a lib and modern cross-platform 'lsusb' \
 that attempts to maintain compatibility with, but also add new features."""

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cyme"
 authors = ["John Whittington <john@jbrengineering.co.uk>"]
-description = "List system USB buses and devices; a modern cross-platform `lsusb`"
+description = "List system USB buses and devices; a modern cross-platform lsusb"
 repository = "https://github.com/tuna-f1sh/cyme"
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -88,3 +88,7 @@ pre-build = ["apt-get update && apt-get install --assume-yes libusb-1.0-0-dev li
 
 [package.metadata.deb]
 section = "utility"
+change-log = "CHANGELOG.md"
+extended-description = """\
+List system USB buses and devices; a lib and modern cross-platform 'lsusb' \
+that attempts to maintain compatibility with, but also add new features."""

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,3 +93,8 @@ changelog = "CHANGELOG.md"
 extended-description = """\
 List system USB buses and devices; a lib and modern cross-platform 'lsusb' \
 that attempts to maintain compatibility with, but also add new features."""
+assets = [
+  ["target/release/cyme", "usr/bin/", "755"],
+  ["README.md", "usr/share/doc/cyme/README", "644"],
+  ["doc/cyme.1", "/usr/share/man/man1/cyme.1", "644"],
+]

--- a/doc/cyme.1
+++ b/doc/cyme.1
@@ -2,11 +2,11 @@
 .el .ds Aq '
 .TH cyme 1  "cyme 1.8.2" 
 .SH NAME
-cyme \- List system USB buses and devices; a modern cross\-platform `lsusb`
+cyme \- List system USB buses and devices; a modern cross\-platform lsusb
 .SH SYNOPSIS
 \fBcyme\fR [\fB\-l\fR|\fB\-\-lsusb\fR] [\fB\-t\fR|\fB\-\-tree\fR] [\fB\-d\fR|\fB\-\-vidpid\fR] [\fB\-s\fR|\fB\-\-show\fR] [\fB\-D\fR|\fB\-\-device\fR] [\fB\-\-filter\-name\fR] [\fB\-\-filter\-serial\fR] [\fB\-\-filter\-class\fR] [\fB\-v\fR|\fB\-\-verbose\fR]... [\fB\-b\fR|\fB\-\-blocks\fR] [\fB\-\-bus\-blocks\fR] [\fB\-\-config\-blocks\fR] [\fB\-\-interface\-blocks\fR] [\fB\-\-endpoint\-blocks\fR] [\fB\-m\fR|\fB\-\-more\fR] [\fB\-\-sort\-devices\fR] [\fB\-\-sort\-buses\fR] [\fB\-\-group\-devices\fR] [\fB\-\-hide\-buses\fR] [\fB\-\-hide\-hubs\fR] [\fB\-\-list\-root\-hubs\fR] [\fB\-\-decimal\fR] [\fB\-\-no\-padding\fR] [\fB\-\-color\fR] [\fB\-\-encoding\fR] [\fB\-\-icon\fR] [\fB\-\-headings\fR] [\fB\-\-json\fR] [\fB\-\-from\-json\fR] [\fB\-F\fR|\fB\-\-force\-libusb\fR] [\fB\-c\fR|\fB\-\-config\fR] [\fB\-z\fR|\fB\-\-debug\fR]... [\fB\-\-mask\-serials\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] 
 .SH DESCRIPTION
-List system USB buses and devices; a modern cross\-platform `lsusb`
+List system USB buses and devices; a modern cross\-platform lsusb
 .SH OPTIONS
 .TP
 \fB\-l\fR, \fB\-\-lsusb\fR


### PR DESCRIPTION
Removes errors from `lintian` #29.  Still not perfect but hopefully good enough until someone wants to officially manage a package.

* Warnings in CHANGELOG I'll leave.
* Unknown field warnings I think are something from cargo-deb and I can't control?
* Spellings info should be fixed with #28 .

```
❯ lintian --display-info --display-experimental --pedantic --show-overrides $CARGO_TARGET_DIR/debian/cyme_1.8.2-1_amd64.deb
W: cyme: syntax-error-in-debian-changelog line 10 "found blank line where expected first heading"
W: cyme: syntax-error-in-debian-changelog line 11 "badly formatted heading line"
W: cyme: syntax-error-in-debian-changelog line 12 "badly formatted heading line"
W: cyme: syntax-error-in-debian-changelog ... use --no-tag-display-limit to see all (or pipe to a file/program)
W: cyme: unknown-control-file sha256sums
W: cyme: unknown-field Vcs-Browser
W: cyme: unknown-field Vcs-Git
W: cyme: unknown-section utility
I: cyme: no-md5sums-control-file
I: cyme: spelling-error-in-binary usr/bin/cyme BuIL Build
I: cyme: spelling-error-in-binary usr/bin/cyme Transciever Transceiver
I: cyme: spelling-error-in-binary usr/bin/cyme charactor character
I: cyme: spelling-error-in-binary ... use --no-tag-display-limit to see all (or pipe to a file/program)
I: cyme: typo-in-manual-page usr/share/man/man1/cyme.1.gz line 337 charactor character
I: cyme: typo-in-manual-page usr/share/man/man1/cyme.1.gz line 344 charactors characters
I: cyme: typo-in-manual-page usr/share/man/man1/cyme.1.gz line 346 charactors characters
I: cyme: typo-in-manual-page ... use --no-tag-display-limit to see all (or pipe to a file/program)
```