### PR TITLE
fix riscv64 build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,11 @@ udevrs = { version = "^0.3.0", optional = true }
 udevlib = { package = "udev", version = "^0.8.0", optional = true }
 rusb = "0.9.4"
 
+[target.riscv64gc-unknown-linux-gnu.dependencies]
+udevrs = { version = "^0.3.0", optional = true }
+udevlib = { package = "udev", version = "^0.8.0", optional = true }
+rusb = "0.9.4"
+
 [features]
 libusb = ["dep:rusb"]
 udev = ["libusb", "dep:udevrs"]


### PR DESCRIPTION
This PR allows cyme to be built on riscv64.

Reported-by: https://archriscv.felixc.at/.status/log.htm?url=logs/cyme/cyme-1.8.4-1.log