### PR TITLE
macOS mod guard

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -314,7 +314,7 @@ fn parse_devpath(s: &str) -> Result<(Option<u8>, Option<u8>)> {
 
 /// macOS can use system_profiler to get USB data and merge with libusb so separate function
 #[cfg(target_os = "macos")]
-fn get_system_profile(args: &Args) -> Result<profiler::SystemProfile> {
+fn get_system_profile_macos(args: &Args) -> Result<profiler::SystemProfile> {
     // if requested or only have libusb, use system_profiler and merge with libusb
     if args.system_profiler || !cfg!(feature = "nusb") {
         if !args.force_libusb
@@ -354,7 +354,6 @@ fn get_system_profile(args: &Args) -> Result<profiler::SystemProfile> {
 }
 
 /// Detects and switches between verbose profiler (extra) and normal profiler
-#[cfg(not(target_os = "macos"))]
 fn get_system_profile(args: &Args) -> Result<profiler::SystemProfile> {
     if args.verbose > 0
         || args.tree
@@ -527,7 +526,15 @@ fn cyme() -> Result<()> {
             }
         }
     } else {
-        get_system_profile(&args)?
+        #[cfg(target_os = "macos")]
+        {
+            get_system_profile_macos(&args)?
+        }
+
+        #[cfg(not(target_os = "macos"))]
+        {
+            get_system_profile(&args)?
+        }
     };
 
     log::trace!("Returned system_profiler data\n\r{:#?}", spusb);

--- a/src/main.rs
+++ b/src/main.rs
@@ -312,7 +312,9 @@ fn parse_devpath(s: &str) -> Result<(Option<u8>, Option<u8>)> {
     }
 }
 
-fn get_macos_system_profile(args: &Args) -> Result<profiler::SystemProfile> {
+/// macOS can use system_profiler to get USB data and merge with libusb so separate function
+#[cfg(target_os = "macos")]
+fn get_system_profile(args: &Args) -> Result<profiler::SystemProfile> {
     // if requested or only have libusb, use system_profiler and merge with libusb
     if args.system_profiler || !cfg!(feature = "nusb") {
         if !args.force_libusb
@@ -351,6 +353,8 @@ fn get_macos_system_profile(args: &Args) -> Result<profiler::SystemProfile> {
     }
 }
 
+/// Detects and switches between verbose profiler (extra) and normal profiler
+#[cfg(not(target_os = "macos"))]
 fn get_system_profile(args: &Args) -> Result<profiler::SystemProfile> {
     if args.verbose > 0
         || args.tree
@@ -522,8 +526,6 @@ fn cyme() -> Result<()> {
                 profiler::read_flat_json_to_phony_bus(file_path.as_str())?
             }
         }
-    } else if cfg!(target_os = "macos") {
-        get_macos_system_profile(&args)?
     } else {
         get_system_profile(&args)?
     };

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -33,6 +33,7 @@ pub use types::*;
 
 #[cfg(feature = "libusb")]
 pub mod libusb;
+#[cfg(target_os = "macos")]
 pub mod macos;
 #[cfg(feature = "nusb")]
 pub mod nusb;

--- a/src/profiler/macos.rs
+++ b/src/profiler/macos.rs
@@ -8,16 +8,9 @@ use std::process::Command;
 ///
 /// Ok result not contain [`usb::DeviceExtra`] because system_profiler does not provide this. Use `get_spusb_with_extra` to combine with libusb output for [`Device`]s with `extra`
 pub fn get_spusb() -> Result<SystemProfile> {
-    let output = if cfg!(target_os = "macos") {
-        Command::new("system_profiler")
-            .args(["-timeout", "5", "-json", "SPUSBDataType"])
-            .output()?
-    } else {
-        return Err(Error::new(
-            ErrorKind::Unsupported,
-            "system_profiler is only supported on macOS",
-        ));
-    };
+    let output = Command::new("system_profiler")
+        .args(["-timeout", "5", "-json", "SPUSBDataType"])
+        .output()?;
 
     if output.status.success() {
         serde_json::from_str(String::from_utf8(output.stdout)?.as_str())


### PR DESCRIPTION
Removes macOS specific `system_profiler` stuff from other targets.