### PR TITLE
Get driver from sysfs symbolic link and use by default before udev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,9 +69,9 @@ udevlib = ["dep:udevlib"]
 usb_test = []
 regex_icon = ["dep:regex"]
 cli_generate = ["dep:clap_complete", "dep:clap_mangen"] # for generating man and completions
-native = ["nusb"] # pure Rust USB and udev bindings
-ffi = ["libusb"] # C bindings for libusb and libudev
-default = ["nusb", "regex_icon"] # default native Rust USB (nusb) with regex icon name lookup
+native = ["nusb", "udev"] # pure Rust USB and udev bindings
+ffi = ["libusb", "udevlib"] # C bindings for libusb and libudev
+default = ["native", "regex_icon"] # default native Rust USB (nusb, udevrs) with regex icon name lookup
 
 [[bin]]
 name = "cyme"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,9 +69,9 @@ udevlib = ["dep:udevlib"]
 usb_test = []
 regex_icon = ["dep:regex"]
 cli_generate = ["dep:clap_complete", "dep:clap_mangen"] # for generating man and completions
-native = ["nusb", "udev"] # pure Rust USB and udev bindings
-ffi = ["libusb", "udevlib"] # C bindings for libusb and libudev
-default = ["nusb", "udev", "regex_icon"] # default libusb C binding (same as lsusb) and (Rust) udevrs with regex icon name lookup
+native = ["nusb"] # pure Rust USB and udev bindings
+ffi = ["libusb"] # C bindings for libusb and libudev
+default = ["nusb", "regex_icon"] # default native Rust USB (nusb) with regex icon name lookup
 
 [[bin]]
 name = "cyme"

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -724,7 +724,17 @@ fn get_sysfs_string(sysfs_name: &str, attr: &str) -> Option<String> {
     #[cfg(target_os = "linux")]
     return std::fs::read_to_string(format!("{}{}/{}", SYSFS_USB_PREFIX, sysfs_name, attr))
         .ok()
-        .map(|s| s.trim().to_string());
+        .map(|s| s.to_string());
+    #[cfg(not(target_os = "linux"))]
+    return None;
+}
+
+#[allow(unused_variables)]
+fn get_sysfs_readlink(sysfs_name: &str, attr: &str) -> Option<String> {
+    #[cfg(target_os = "linux")]
+    return std::fs::read_link(format!("{}{}/{}", SYSFS_USB_PREFIX, sysfs_name, attr))
+        .ok()
+        .map(|s| s.file_name().map(|f| f.to_string_lossy().to_string())).flatten();
     #[cfg(not(target_os = "linux"))]
     return None;
 }

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -736,7 +736,7 @@ fn get_sysfs_readlink(sysfs_name: &str, attr: &str) -> Option<String> {
     #[cfg(target_os = "linux")]
     return std::fs::read_link(format!("{}{}/{}", SYSFS_USB_PREFIX, sysfs_name, attr))
         .ok()
-        .map(|s| s.file_name().map(|f| f.to_string_lossy().to_string())).flatten();
+        .and_then(|s| s.file_name().map(|f| f.to_string_lossy().to_string()));
     #[cfg(not(target_os = "linux"))]
     return None;
 }

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -721,6 +721,7 @@ where
 /// Get a USB device attribute String from sysfs on Linux
 #[allow(unused_variables)]
 fn get_sysfs_string(sysfs_name: &str, attr: &str) -> Option<String> {
+    log::trace!("Getting sysfs string at {}{}", sysfs_name, attr);
     #[cfg(target_os = "linux")]
     return std::fs::read_to_string(format!("{}{}/{}", SYSFS_USB_PREFIX, sysfs_name, attr))
         .ok()
@@ -731,6 +732,7 @@ fn get_sysfs_string(sysfs_name: &str, attr: &str) -> Option<String> {
 
 #[allow(unused_variables)]
 fn get_sysfs_readlink(sysfs_name: &str, attr: &str) -> Option<String> {
+    log::trace!("readlink at {}{}", sysfs_name, attr);
     #[cfg(target_os = "linux")]
     return std::fs::read_link(format!("{}{}/{}", SYSFS_USB_PREFIX, sysfs_name, attr))
         .ok()

--- a/src/udev.rs
+++ b/src/udev.rs
@@ -24,6 +24,7 @@ pub struct UdevInfo {
 pub fn get_udev_info(port_path: &str) -> Result<UdevInfo, Error> {
     let path: String = format!("/sys/bus/usb/devices/{}", port_path);
     let mut device = UdevDevice::new_from_syspath(udev_new(), &path).map_err(|e| {
+        log::error!("Failed to get udev info for device at {}: Error({})", path, e);
         Error::new(
             ErrorKind::Udev,
             &format!(
@@ -51,6 +52,7 @@ pub fn get_udev_info(port_path: &str) -> Result<UdevInfo, Error> {
 pub fn get_udev_driver_name(port_path: &str) -> Result<Option<String>, Error> {
     let path: String = format!("/sys/bus/usb/devices/{}", port_path);
     let mut device = UdevDevice::new_from_syspath(udev_new(), &path).map_err(|e| {
+        log::error!("Failed to get udev info for device at {}: Error({})", path, e);
         Error::new(
             ErrorKind::Udev,
             &format!(
@@ -73,6 +75,7 @@ pub fn get_udev_driver_name(port_path: &str) -> Result<Option<String>, Error> {
 pub fn get_udev_syspath(port_path: &str) -> Result<Option<String>, Error> {
     let path: String = format!("/sys/bus/usb/devices/{}", port_path);
     let device = UdevDevice::new_from_syspath(udev_new(), &path).map_err(|e| {
+        log::error!("Failed to get udev info for device at {}: Error({})", path, e);
         Error::new(
             ErrorKind::Udev,
             &format!(
@@ -91,7 +94,7 @@ pub fn get_udev_syspath(port_path: &str) -> Result<Option<String>, Error> {
 /// These attributes are generally readable by all users.
 ///
 /// NOTE: In general you should read from sysfs directly as it does not
-///       depend on the udev feature. See `get_sysfs_string()` in lsusb.rs
+///       depend on the udev feature. See `get_sysfs_string()` in profiler.rs
 ///
 /// ```no_run
 /// use cyme::udev::get_udev_attribute;
@@ -105,6 +108,7 @@ pub fn get_udev_attribute<T: AsRef<std::ffi::OsStr> + std::fmt::Display + Into<S
 ) -> Result<Option<String>, Error> {
     let path: String = format!("/sys/bus/usb/devices/{}", port_path);
     let mut device = UdevDevice::new_from_syspath(udev_new(), &path).map_err(|e| {
+        log::error!("Failed to get udev attribute {} for device at {}: Error({})", attribute, path, e);
         Error::new(
             ErrorKind::Udev,
             &format!(
@@ -142,6 +146,7 @@ pub mod hwdb {
     /// ```
     pub fn get(modalias: &str, key: &'static str) -> Result<Option<String>, Error> {
         let mut hwdb = UdevHwdb::new(udev_new()).map_err(|e| {
+            log::error!("Failed to get hwdb: Error({})", e);
             Error::new(
                 ErrorKind::Udev,
                 &format!("Failed to get hwdb: Error({})", e),

--- a/src/udev.rs
+++ b/src/udev.rs
@@ -12,6 +12,24 @@ pub struct UdevInfo {
     pub syspath: Option<String>,
 }
 
+fn get_device(port_path: &str) -> Result<UdevDevice, Error> {
+    let path: String = format!("/sys/bus/usb/devices/{}", port_path);
+    UdevDevice::new_from_syspath(udev_new(), &path).map_err(|e| {
+        log::error!(
+            "Failed to get udev info for device at {}: Error({})",
+            path,
+            e
+        );
+        Error::new(
+            ErrorKind::Udev,
+            &format!(
+                "Failed to get udev info for device at {}: Error({})",
+                path, e
+            ),
+        )
+    })
+}
+
 /// Lookup the driver and syspath for a device given the `port_path`. Returns [`UdevInfo`] containing both.
 ///
 /// ```no_run
@@ -22,17 +40,7 @@ pub struct UdevInfo {
 /// assert_eq!(udevi.syspath.unwrap().contains("usb1/1-0:1.0"), true);
 /// ```
 pub fn get_udev_info(port_path: &str) -> Result<UdevInfo, Error> {
-    let path: String = format!("/sys/bus/usb/devices/{}", port_path);
-    let mut device = UdevDevice::new_from_syspath(udev_new(), &path).map_err(|e| {
-        log::error!("Failed to get udev info for device at {}: Error({})", path, e);
-        Error::new(
-            ErrorKind::Udev,
-            &format!(
-                "Failed to get udev info for device at {}: Error({})",
-                path, e
-            ),
-        )
-    })?;
+    let mut device = get_device(port_path)?;
 
     Ok({
         UdevInfo {
@@ -50,17 +58,7 @@ pub fn get_udev_info(port_path: &str) -> Result<UdevInfo, Error> {
 /// assert_eq!(driver, Some("hub".into()));
 /// ```
 pub fn get_udev_driver_name(port_path: &str) -> Result<Option<String>, Error> {
-    let path: String = format!("/sys/bus/usb/devices/{}", port_path);
-    let mut device = UdevDevice::new_from_syspath(udev_new(), &path).map_err(|e| {
-        log::error!("Failed to get udev info for device at {}: Error({})", path, e);
-        Error::new(
-            ErrorKind::Udev,
-            &format!(
-                "Failed to get udev info for device at {}: Error({})",
-                path, e
-            ),
-        )
-    })?;
+    let mut device = get_device(port_path)?;
 
     Ok(device.get_driver().map(|s| s.trim().to_string()))
 }
@@ -73,17 +71,7 @@ pub fn get_udev_driver_name(port_path: &str) -> Result<Option<String>, Error> {
 /// assert_eq!(syspath.unwrap().contains("usb1/1-0:1.0"), true);
 /// ```
 pub fn get_udev_syspath(port_path: &str) -> Result<Option<String>, Error> {
-    let path: String = format!("/sys/bus/usb/devices/{}", port_path);
-    let device = UdevDevice::new_from_syspath(udev_new(), &path).map_err(|e| {
-        log::error!("Failed to get udev info for device at {}: Error({})", path, e);
-        Error::new(
-            ErrorKind::Udev,
-            &format!(
-                "Failed to get udev info for device at {}: Error({})",
-                path, e
-            ),
-        )
-    })?;
+    let device = get_device(port_path)?;
 
     Ok(Some(device.syspath().trim().to_string()))
 }
@@ -106,17 +94,7 @@ pub fn get_udev_attribute<T: AsRef<std::ffi::OsStr> + std::fmt::Display + Into<S
     port_path: &str,
     attribute: T,
 ) -> Result<Option<String>, Error> {
-    let path: String = format!("/sys/bus/usb/devices/{}", port_path);
-    let mut device = UdevDevice::new_from_syspath(udev_new(), &path).map_err(|e| {
-        log::error!("Failed to get udev attribute {} for device at {}: Error({})", attribute, path, e);
-        Error::new(
-            ErrorKind::Udev,
-            &format!(
-                "Failed to get udev attribute {} for device at {}: Error({})",
-                attribute, path, e
-            ),
-        )
-    })?;
+    let mut device = get_device(port_path)?;
 
     Ok(device
         .get_sysattr_value(&attribute.into())


### PR DESCRIPTION
Quicker and allows `cyme` to operate without 'udev' or 'udevlib' dependences. Leaving as part of default features for now however.