### PR TITLE
make install target improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ DOCS = doc/_$(PROJECT_NAME) doc/$(PROJECT_NAME).1 doc/$(PROJECT_NAME).bash doc/c
 release: $(RELEASE_BIN)
 
 install:
-	$(shell ./install.sh)
+	./install.sh
 
 generated: $(DOCS)
 

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,7 @@ function cargo_project_name() {
 bin_name=$(cargo_project_name)
 # with remaining args
 cargo install --locked "$@" --path .
+install -D -m 0755 "${HOME}/.cargo/bin/${bin_name}" "${DESTDIR}/usr/bin/${bin_name}"
 
 # supporting stuff
 if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -18,12 +19,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   fi
   cp -v ./doc/"${bin_name}".1 /usr/local/share/man/man1/
 elif [[ "$OSTYPE" == "linux"* ]]; then
-  if [[ -d /usr/share/bash-completion/completions ]]; then
-    cp -v ./doc/"${bin_name}".bash /usr/share/bash-completion/completions/
-  fi
-  if [[ -d /usr/share/zsh/site-functions ]]; then
-    cp -v ./doc/_"${bin_name}" /usr/share/zsh/site-functions/
-  fi
-  # install man page
-  cp -v ./doc/"${bin_name}".1 /usr/share/man/man1/
+install -D -m 0644 ./doc/"${bin_name}".bash "${DESTDIR}/usr/share/bash-completion/completions/${bin_name}.bash"
+install -D -m 0644 ./doc/_"${bin_name}" "${DESTDIR}/usr/share/zsh/site-functions/_${bin_name}"
+install -D -m 0644 ./doc/"${bin_name}".1 "${DESTDIR}/usr/share/man/man1/${bin_name}.1"
 fi


### PR DESCRIPTION
Just a few little things that linux distros would probably have a patch for themselves that make sense to be upstream I think.

* Removes make shell that isn't needed
* Updates install.sh to use DESTDIR on linux for installation path (and install cyme into /usr/bin under DESTDIR as well)
 