### PR TITLE
udev: use subsystem_system so udev sources device path

### DIFF
--- a/src/udev.rs
+++ b/src/udev.rs
@@ -13,7 +13,7 @@ pub struct UdevInfo {
 }
 
 fn get_device(port_path: &str) -> Result<UdevDevice, Error> {
-    UdevDevice::new_from_subsystem_sysname(udev_new(), "usb", &port_path).map_err(|e| {
+    UdevDevice::new_from_subsystem_sysname(udev_new(), "usb", port_path).map_err(|e| {
         log::error!(
             "Failed to get udev info for device at {}: Error({})",
             port_path,

--- a/src/udev.rs
+++ b/src/udev.rs
@@ -13,18 +13,17 @@ pub struct UdevInfo {
 }
 
 fn get_device(port_path: &str) -> Result<UdevDevice, Error> {
-    let path: String = format!("/sys/bus/usb/devices/{}", port_path);
-    UdevDevice::new_from_syspath(udev_new(), &path).map_err(|e| {
+    UdevDevice::new_from_subsystem_sysname(udev_new(), "usb", &port_path).map_err(|e| {
         log::error!(
             "Failed to get udev info for device at {}: Error({})",
-            path,
+            port_path,
             e
         );
         Error::new(
             ErrorKind::Udev,
             &format!(
                 "Failed to get udev info for device at {}: Error({})",
-                path, e
+                port_path, e
             ),
         )
     })

--- a/src/udev_ffi.rs
+++ b/src/udev_ffi.rs
@@ -14,21 +14,22 @@ pub struct UdevInfo {
 }
 
 fn get_device(port_path: &str) -> Result<udevlib::Device, Error> {
-    let path: String = format!("/sys/bus/usb/devices/{}", port_path);
-    udevlib::Device::from_syspath(Path::new(&path)).map_err(|e| {
-        log::error!(
-            "Failed to get udev info for device at {}: Error({})",
-            path,
-            e
-        );
-        Error::new(
-            ErrorKind::Udev,
-            &format!(
+    udevlib::Device::from_subsystem_sysname(String::from("usb"), port_path.to_string()).map_err(
+        |e| {
+            log::error!(
                 "Failed to get udev info for device at {}: Error({})",
-                path, e
-            ),
-        )
-    })
+                port_path,
+                e
+            );
+            Error::new(
+                ErrorKind::Udev,
+                &format!(
+                    "Failed to get udev info for device at {}: Error({})",
+                    port_path, e
+                ),
+            )
+        },
+    )
 }
 
 /// Lookup the driver and syspath for a device given the `port_path`. Returns [`UdevInfo`] containing both.
@@ -41,7 +42,7 @@ fn get_device(port_path: &str) -> Result<udevlib::Device, Error> {
 /// assert_eq!(udevi.syspath.unwrap().contains("usb1/1-0:1.0"), true);
 /// ```
 pub fn get_udev_info(port_path: &str) -> Result<UdevInfo, Error> {
-    let mut device = get_device(port_path)?;
+    let device = get_device(port_path)?;
 
     Ok({
         UdevInfo {
@@ -61,7 +62,7 @@ pub fn get_udev_info(port_path: &str) -> Result<UdevInfo, Error> {
 /// assert_eq!(driver, Some("hub".into()));
 /// ```
 pub fn get_udev_driver_name(port_path: &str) -> Result<Option<String>, Error> {
-    let mut device = get_device(port_path)?;
+    let device = get_device(port_path)?;
 
     Ok(device
         .driver()


### PR DESCRIPTION
Ideal would be to pass device `get_dev_path` but not sure what API allows that (if there is one). The `new_from_subsystem_sysname` resolves the sysfs on udevrs and udevlib.