### PR TITLE
Android support (rooted)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build:
-    name: ${{ matrix.job.os }}-(${{ matrix.job.target }})
+    name: ${{ matrix.job.os }}-${{ matrix.job.target }}
     runs-on: ${{ matrix.job.os }}
     strategy:
       fail-fast: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,19 +44,7 @@ nusb = { git = "https://github.com/tuna-f1sh/nusb", branch = "cyme" }
 diff = "0.1"
 assert-json-diff = "2.0.2"
 
-[target.x86_64-unknown-linux-gnu.dependencies]
-udevrs = { version = "^0.3.0", optional = true }
-udevlib = { package = "udev", version = "^0.8.0", optional = true }
-
-[target.arm-unknown-linux-gnueabihf.dependencies]
-udevrs = { version = "^0.3.0", optional = true }
-udevlib = { package = "udev", version = "^0.8.0", optional = true }
-
-[target.aarch64-unknown-linux-gnu.dependencies]
-udevrs = { version = "^0.3.0", optional = true }
-udevlib = { package = "udev", version = "^0.8.0", optional = true }
-
-[target.riscv64gc-unknown-linux-gnu.dependencies]
+[target.'cfg(target_os="linux")'.dependencies]
 udevrs = { version = "^0.3.0", optional = true }
 udevlib = { package = "udev", version = "^0.8.0", optional = true }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -380,9 +380,6 @@ fn print_lsusb(
         if !cfg!(target_os = "linux") {
             log::warn!("Most of the data in a lsusb style tree is applicable to Linux only!");
         }
-        if !cfg!(feature = "udev") {
-            log::warn!("Without udev, lsusb style tree content will not match lsusb: driver and syspath will be missing");
-        }
         lsusb::print_tree(sp_usb, settings)
     } else {
         // can't print verbose if not using libusb

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -723,22 +723,22 @@ where
 #[allow(unused_variables)]
 fn get_sysfs_string(sysfs_name: &str, attr: &str) -> Option<String> {
     log::trace!("Getting sysfs string at {}{}", sysfs_name, attr);
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     return std::fs::read_to_string(format!("{}{}/{}", SYSFS_USB_PREFIX, sysfs_name, attr))
         .ok()
         .map(|s| s.trim().to_string());
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
     return None;
 }
 
 #[allow(unused_variables)]
 fn get_sysfs_readlink(sysfs_name: &str, attr: &str) -> Option<String> {
     log::trace!("readlink at {}{}", sysfs_name, attr);
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     return std::fs::read_link(format!("{}{}/{}", SYSFS_USB_PREFIX, sysfs_name, attr))
         .ok()
         .and_then(|s| s.file_name().map(|f| f.to_string_lossy().to_string()));
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
     return None;
 }
 
@@ -763,9 +763,9 @@ fn get_udev_syspath(port_path: &str) -> Result<Option<String>> {
 /// Get the USB device syspath based on the default location "/sys/bus/usb/devices" on Linux
 #[allow(unused_variables)]
 fn get_syspath(port_path: &str) -> Option<String> {
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     return Some(format!("{}{}", SYSFS_USB_PREFIX, port_path));
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
     return None;
 }
 


### PR DESCRIPTION
nusb includes Android as a compilation target so it makes sense to add Android to the Linux guards.

It will only work on rooted devices as it requires sysfs.