### PR TITLE
Update lsusb tree mode to match lsusb

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The name comes from the technical term for the type of blossom on a Apple tree: 
 
 # Features
 
-* Compatible with `lsusb` using `--lsusb` argument. Supports all arguments including `--verbose` output - fully parsed device descriptors! Output is identical for use with no args (list), almost matching for tree (driver port number not included) and should match for verbose (perhaps formatting differences).
+* Compatible with `lsusb` using `--lsusb` argument. Supports all arguments including `--verbose` output - fully parsed device descriptors! Output is identical for use with no args (list), tree (excluding drivers on non-Linux) and should match for verbose (perhaps formatting differences).
 * Default build is a native Rust profiler using [nusb](https://docs.rs/nusb/latest/nusb).
 * Filters like `lsusb` but that also work when printing `--tree`. Adds `--filter_name`, `--filter_serial`, `--filter_class` and option to hide empty `--hide-buses`/`--hide-hubs`.
 * Improved `--tree` mode; shows device, configurations, interfaces and endpoints as tree depending on level of `--verbose`.

--- a/src/profiler/types.rs
+++ b/src/profiler/types.rs
@@ -374,7 +374,7 @@ impl Bus {
 
             Vec::from([(
                 format!(
-                    "Bus {:02}.Port 1: Dev 1, Class=root_hub, Driver={}, {}",
+                    "Bus {:03}.Port 001: Dev 001, Class=root_hub, Driver={}, {}",
                     self.get_bus_number().unwrap_or(0xff),
                     driver,
                     speed
@@ -396,7 +396,7 @@ impl Bus {
             log::warn!("Failed to get root_device in bus");
             Vec::from([(
                 format!(
-                    "Bus {:02}.Port 1: Dev 1, Class=root_hub, Driver=[none],",
+                    "Bus {:03}.Port 001: Dev 001, Class=root_hub, Driver=[none],",
                     self.get_bus_number().unwrap_or(0xff),
                 ),
                 format!(
@@ -1156,7 +1156,7 @@ impl Device {
                 for interface in &config.interfaces {
                     format_strs.push((
                         format!(
-                            "Port {:}: Dev {:}, If {}, Class={}, Driver={}, {}",
+                            "Port {:03}: Dev {:03}, If {}, Class={}, Driver={}, {}",
                             self.get_branch_position(),
                             self.location_id.number,
                             interface.number,
@@ -1184,7 +1184,7 @@ impl Device {
             log::warn!("Rendering {} lsusb tree without extra data because it is missing. No configurations or interfaces will be shown", self);
             format_strs.push((
                 format!(
-                    "Port {:}: Dev {:}, If {}, Class={}, Driver={}, {}",
+                    "Port {:03}: Dev {:03}, If {}, Class={}, Driver={}, {}",
                     self.get_branch_position(),
                     self.location_id.number,
                     0,

--- a/src/profiler/types.rs
+++ b/src/profiler/types.rs
@@ -357,26 +357,34 @@ impl Bus {
             };
 
             // no fallback for lsusb tree mode
-            let (driver, vendor, product) = match &root_device.extra {
+            let (driver, vendor, product, ports) = match &root_device.extra {
                 Some(v) => (
                     v.driver.to_owned().unwrap_or(String::from("[none]")),
                     v.vendor.to_owned().unwrap_or(String::from("[unknown]")),
                     v.product_name
                         .to_owned()
                         .unwrap_or(String::from("[unknown]")),
+                    v.hub.to_owned().map(|h| h.num_ports),
                 ),
                 None => (
                     String::from("[none]"),
                     String::from("[unknown]"),
                     String::from("[unknown]"),
+                    None,
                 ),
+            };
+
+            let driver_string = if let Some(ports) = ports {
+                format!("{}/{}p", driver, ports)
+            } else {
+                driver
             };
 
             Vec::from([(
                 format!(
                     "Bus {:03}.Port 001: Dev 001, Class=root_hub, Driver={}, {}",
                     self.get_bus_number().unwrap_or(0xff),
-                    driver,
+                    driver_string,
                     speed
                 ),
                 format!(
@@ -1152,8 +1160,19 @@ impl Device {
         };
 
         if let Some(extra) = self.extra.as_ref() {
+            let ports = extra.hub.as_ref().map(|hub| hub.num_ports);
             for config in &extra.configurations {
                 for interface in &config.interfaces {
+                    let interface_driver = interface
+                        .driver
+                        .as_ref()
+                        .map_or(String::from("[none]"), |d| d.to_string());
+                    // if there are ports (device is hub), add them to the driver string
+                    let driver_string = if let Some(p) = ports {
+                        format!("{}/{}p", interface_driver, p)
+                    } else {
+                        interface_driver
+                    };
                     format_strs.push((
                         format!(
                             "Port {:03}: Dev {:03}, If {}, Class={}, Driver={}, {}",
@@ -1161,7 +1180,7 @@ impl Device {
                             self.location_id.number,
                             interface.number,
                             interface.class.to_lsusb_string(),
-                            interface.driver.as_ref().unwrap_or(&String::from("[none]")),
+                            driver_string,
                             speed
                         ),
                         format!(

--- a/tests/data/lsusb_tree.txt
+++ b/tests/data/lsusb_tree.txt
@@ -1,19 +1,19 @@
-/:  Bus 01.Port 1: Dev 1, Class=root_hub, Driver=hub, 480M
-    |__ Port 2: Dev 2, If 0, Class=Human Interface Device, Driver=usbhid, 480M
-    |__ Port 2: Dev 2, If 1, Class=Human Interface Device, Driver=usbhid, 480M
-    |__ Port 6: Dev 3, If 0, Class=Printer, Driver=usblp, 480M
-/:  Bus 02.Port 1: Dev 1, Class=root_hub, Driver=hub, 12M
-    |__ Port 2: Dev 22, If 0, Class=Hub, Driver=hub, 12M
-        |__ Port 1: Dev 23, If 0, Class=Communications, Driver=cdc_acm, 12M
-        |__ Port 1: Dev 23, If 1, Class=CDC Data, Driver=cdc_acm, 12M
-        |__ Port 1: Dev 23, If 2, Class=Communications, Driver=cdc_acm, 12M
-        |__ Port 1: Dev 23, If 3, Class=CDC Data, Driver=cdc_acm, 12M
-        |__ Port 1: Dev 23, If 4, Class=Vendor Specific Class, Driver=[none], 12M
-        |__ Port 8: Dev 24, If 0, Class=Communications, Driver=cdc_acm, 12M
-        |__ Port 8: Dev 24, If 1, Class=CDC Data, Driver=cdc_acm, 12M
-        |__ Port 8: Dev 24, If 2, Class=Communications, Driver=cdc_acm, 12M
-        |__ Port 8: Dev 24, If 3, Class=CDC Data, Driver=cdc_acm, 12M
-        |__ Port 8: Dev 24, If 4, Class=Application Specific Interface, Driver=[none], 12M
-        |__ Port 8: Dev 24, If 5, Class=Vendor Specific Class, Driver=[none], 12M
-/:  Bus 03.Port 1: Dev 1, Class=root_hub, Driver=hub, 480M
-/:  Bus 04.Port 1: Dev 1, Class=root_hub, Driver=hub, 10000M
+/:  Bus 001.Port 001: Dev 001, Class=root_hub, Driver=hub, 480M
+    |__ Port 002: Dev 002, If 0, Class=Human Interface Device, Driver=usbhid, 480M
+    |__ Port 002: Dev 002, If 1, Class=Human Interface Device, Driver=usbhid, 480M
+    |__ Port 006: Dev 003, If 0, Class=Printer, Driver=usblp, 480M
+/:  Bus 002.Port 001: Dev 001, Class=root_hub, Driver=hub, 12M
+    |__ Port 002: Dev 022, If 0, Class=Hub, Driver=hub, 12M
+        |__ Port 001: Dev 023, If 0, Class=Communications, Driver=cdc_acm, 12M
+        |__ Port 001: Dev 023, If 1, Class=CDC Data, Driver=cdc_acm, 12M
+        |__ Port 001: Dev 023, If 2, Class=Communications, Driver=cdc_acm, 12M
+        |__ Port 001: Dev 023, If 3, Class=CDC Data, Driver=cdc_acm, 12M
+        |__ Port 001: Dev 023, If 4, Class=Vendor Specific Class, Driver=[none], 12M
+        |__ Port 008: Dev 024, If 0, Class=Communications, Driver=cdc_acm, 12M
+        |__ Port 008: Dev 024, If 1, Class=CDC Data, Driver=cdc_acm, 12M
+        |__ Port 008: Dev 024, If 2, Class=Communications, Driver=cdc_acm, 12M
+        |__ Port 008: Dev 024, If 3, Class=CDC Data, Driver=cdc_acm, 12M
+        |__ Port 008: Dev 024, If 4, Class=Application Specific Interface, Driver=[none], 12M
+        |__ Port 008: Dev 024, If 5, Class=Vendor Specific Class, Driver=[none], 12M
+/:  Bus 003.Port 001: Dev 001, Class=root_hub, Driver=hub, 480M
+/:  Bus 004.Port 001: Dev 001, Class=root_hub, Driver=hub, 10000M

--- a/tests/data/lsusb_tree_verbose.txt
+++ b/tests/data/lsusb_tree_verbose.txt
@@ -1,57 +1,57 @@
-/:  Bus 01.Port 1: Dev 1, Class=root_hub, Driver=hub, 480M
+/:  Bus 001.Port 001: Dev 001, Class=root_hub, Driver=hub, 480M
     ID 1d6b:0002 Linux Foundation 2.0 root hub
     /sys/bus/usb/devices/usb1  /dev/bus/usb/001/001
-    |__ Port 2: Dev 2, If 0, Class=Human Interface Device, Driver=usbhid, 480M
+    |__ Port 002: Dev 002, If 0, Class=Human Interface Device, Driver=usbhid, 480M
         ID 203a:fffc PARALLELS [unknown]
         /sys/bus/usb/devices/1-2  /dev/bus/usb/001/002
-    |__ Port 2: Dev 2, If 1, Class=Human Interface Device, Driver=usbhid, 480M
+    |__ Port 002: Dev 002, If 1, Class=Human Interface Device, Driver=usbhid, 480M
         ID 203a:fffc PARALLELS [unknown]
         /sys/bus/usb/devices/1-2  /dev/bus/usb/001/002
-    |__ Port 6: Dev 3, If 0, Class=Printer, Driver=usblp, 480M
+    |__ Port 006: Dev 003, If 0, Class=Printer, Driver=usblp, 480M
         ID 203a:fffa PARALLELS [unknown]
         /sys/bus/usb/devices/1-6  /dev/bus/usb/001/003
-/:  Bus 02.Port 1: Dev 1, Class=root_hub, Driver=hub, 12M
+/:  Bus 002.Port 001: Dev 001, Class=root_hub, Driver=hub, 12M
     ID 1d6b:0001 Linux Foundation 1.1 root hub
     /sys/bus/usb/devices/usb2  /dev/bus/usb/002/001
-    |__ Port 2: Dev 22, If 0, Class=Hub, Driver=hub, 12M
+    |__ Port 002: Dev 022, If 0, Class=Hub, Driver=hub, 12M
         ID 203a:fffe PARALLELS [unknown]
         /sys/bus/usb/devices/2-2  /dev/bus/usb/002/022
-        |__ Port 1: Dev 23, If 0, Class=Communications, Driver=cdc_acm, 12M
+        |__ Port 001: Dev 023, If 0, Class=Communications, Driver=cdc_acm, 12M
             ID 1366:1050 SEGGER [unknown]
             /sys/bus/usb/devices/2-2.1  /dev/bus/usb/002/023
-        |__ Port 1: Dev 23, If 1, Class=CDC Data, Driver=cdc_acm, 12M
+        |__ Port 001: Dev 023, If 1, Class=CDC Data, Driver=cdc_acm, 12M
             ID 1366:1050 SEGGER [unknown]
             /sys/bus/usb/devices/2-2.1  /dev/bus/usb/002/023
-        |__ Port 1: Dev 23, If 2, Class=Communications, Driver=cdc_acm, 12M
+        |__ Port 001: Dev 023, If 2, Class=Communications, Driver=cdc_acm, 12M
             ID 1366:1050 SEGGER [unknown]
             /sys/bus/usb/devices/2-2.1  /dev/bus/usb/002/023
-        |__ Port 1: Dev 23, If 3, Class=CDC Data, Driver=cdc_acm, 12M
+        |__ Port 001: Dev 023, If 3, Class=CDC Data, Driver=cdc_acm, 12M
             ID 1366:1050 SEGGER [unknown]
             /sys/bus/usb/devices/2-2.1  /dev/bus/usb/002/023
-        |__ Port 1: Dev 23, If 4, Class=Vendor Specific Class, Driver=[none], 12M
+        |__ Port 001: Dev 023, If 4, Class=Vendor Specific Class, Driver=[none], 12M
             ID 1366:1050 SEGGER [unknown]
             /sys/bus/usb/devices/2-2.1  /dev/bus/usb/002/023
-        |__ Port 8: Dev 24, If 0, Class=Communications, Driver=cdc_acm, 12M
+        |__ Port 008: Dev 024, If 0, Class=Communications, Driver=cdc_acm, 12M
             ID 1d50:6018 OpenMoko, Inc. Black Magic Debug Probe (Application)
             /sys/bus/usb/devices/2-2.8  /dev/bus/usb/002/024
-        |__ Port 8: Dev 24, If 1, Class=CDC Data, Driver=cdc_acm, 12M
+        |__ Port 008: Dev 024, If 1, Class=CDC Data, Driver=cdc_acm, 12M
             ID 1d50:6018 OpenMoko, Inc. Black Magic Debug Probe (Application)
             /sys/bus/usb/devices/2-2.8  /dev/bus/usb/002/024
-        |__ Port 8: Dev 24, If 2, Class=Communications, Driver=cdc_acm, 12M
+        |__ Port 008: Dev 024, If 2, Class=Communications, Driver=cdc_acm, 12M
             ID 1d50:6018 OpenMoko, Inc. Black Magic Debug Probe (Application)
             /sys/bus/usb/devices/2-2.8  /dev/bus/usb/002/024
-        |__ Port 8: Dev 24, If 3, Class=CDC Data, Driver=cdc_acm, 12M
+        |__ Port 008: Dev 024, If 3, Class=CDC Data, Driver=cdc_acm, 12M
             ID 1d50:6018 OpenMoko, Inc. Black Magic Debug Probe (Application)
             /sys/bus/usb/devices/2-2.8  /dev/bus/usb/002/024
-        |__ Port 8: Dev 24, If 4, Class=Application Specific Interface, Driver=[none], 12M
+        |__ Port 008: Dev 024, If 4, Class=Application Specific Interface, Driver=[none], 12M
             ID 1d50:6018 OpenMoko, Inc. Black Magic Debug Probe (Application)
             /sys/bus/usb/devices/2-2.8  /dev/bus/usb/002/024
-        |__ Port 8: Dev 24, If 5, Class=Vendor Specific Class, Driver=[none], 12M
+        |__ Port 008: Dev 024, If 5, Class=Vendor Specific Class, Driver=[none], 12M
             ID 1d50:6018 OpenMoko, Inc. Black Magic Debug Probe (Application)
             /sys/bus/usb/devices/2-2.8  /dev/bus/usb/002/024
-/:  Bus 03.Port 1: Dev 1, Class=root_hub, Driver=hub, 480M
+/:  Bus 003.Port 001: Dev 001, Class=root_hub, Driver=hub, 480M
     ID 1d6b:0002 Linux Foundation 2.0 root hub
     /sys/bus/usb/devices/usb3  /dev/bus/usb/003/001
-/:  Bus 04.Port 1: Dev 1, Class=root_hub, Driver=hub, 10000M
+/:  Bus 004.Port 001: Dev 001, Class=root_hub, Driver=hub, 10000M
     ID 1d6b:0003 Linux Foundation 3.0 root hub
     /sys/bus/usb/devices/usb4  /dev/bus/usb/004/001


### PR DESCRIPTION
Updates to bring `--lsusb --tree` inline with `lsusb`.

* Pads Port and Dev number with 3 leading zeros like lsusb.
* Adds the number of ports to the driver if device is a hub: eg `xhci_hcd/4p` - 4 ports. 
* `get_sysfs_readlink` will switch based on root_hub (usbX) to obtain host controller driver like `lsusb`. More useful than generic 'usb' driver.