### PR TITLE
Hide `--gen` behind `cli_generate` feature

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -166,6 +166,7 @@ struct Args {
     mask_serials: Option<display::MaskSerial>,
 
     /// Generate cli completions and man page
+    #[cfg(feature = "cli_generate")]
     #[arg(long, hide = true, exclusive = true)]
     gen: bool,
 


### PR DESCRIPTION
Hello!

I tried generating shell completions for packaging purposes, and got a surprising result when it acted as if no flag had been provided. This should remove the surprise :)