### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
       with:
         components: clippy
     - uses: actions/checkout@v4
-    - run: cargo clippy --all-targets --all-features -- -Dwarnings
+    - run: cargo clippy --all-targets -- -Dwarnings
 
   build:
     name: ${{ matrix.job.os }}-${{ matrix.job.target }}
@@ -114,6 +114,12 @@ jobs:
         run: |
           echo "CARGO_CMD=cross" >> "$GITHUB_ENV"
           cargo install cross
+
+      - name: Clippy
+        id: clippy
+        shell: bash
+        if: matrix.job.use-cross == false
+        run: cargo clippy --all-targets --all-features -- -Dwarnings
 
       - name: Test
         id: test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
     types:
       - created
 
+env:
+  CARGO_CMD: cargo
+
 name: Test, build and package
 jobs:
   crate_metadata:
@@ -138,6 +141,10 @@ jobs:
         run: |
           make generated
           git diff --exit-code
+        env:
+          CARGO_FLAGS: ${{ matrix.job.feature-flags }}
+          CARGO_CMD: ${{ env.CARGO_CMD }}
+          TARGET: ${{ matrix.job.target }}
 
       - name: Build release
         id: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,11 @@ on:
   release:
     types:
       - created
+  workflow_dispatch:
 
 env:
   CARGO_CMD: cargo
+  RUSTFLAGS: "-Dwarnings"
 
 name: Test, build and package
 jobs:
@@ -42,15 +44,7 @@ jobs:
     - uses: actions/checkout@v4
     - run: cargo fmt -- --check
 
-  # clippy:
-  #   name: Ensure 'cargo clippy' has no warnings
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: dtolnay/rust-toolchain@stable
-  #     with:
-  #       components: clippy
-  #   - uses: actions/checkout@v4
-  #   - run: cargo clippy --all-targets -- -Dwarnings
+  # Clippy pre-check would be nice but OS dependant features and libusb deps for all-features requires in matrix
 
   build:
     name: ${{ matrix.job.os }}-${{ matrix.job.target }}
@@ -66,6 +60,7 @@ jobs:
           - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, use-cross: false, feature-flags: ""  }
           - { os: macos-latest, target: universal-apple-darwin, use-cross: false, feature-flags: ""  }
     outputs:
+      # could use these for release job?
       # pkg-linux-aarch64: ${{ steps.package.outputs.pkg-aarch64-unknown-linux-gnu }}
       # pkg-linux-x86_64: ${{ steps.package.outputs.pkg-x86_64-unknown-linux-gnu }}
       # pkg-windows-x86_64: ${{ steps.package.outputs.pkg-x86_64-pc-windows-gnu }}
@@ -79,6 +74,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
+            ~/.cargo/bin/cargo-deb
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: dtolnay/rust-toolchain@stable
@@ -118,15 +114,17 @@ jobs:
           echo "CARGO_CMD=cross" >> "$GITHUB_ENV"
           cargo install cross
 
-      - name: Clippy
+      - name: Clippy check no warnings
         id: clippy
         shell: bash
+        # cross targets should be covered
         if: matrix.job.use-cross == false
-        run: cargo clippy --all-targets --all-features -- -Dwarnings
+        run: cargo clippy --all-targets --all-features
 
       - name: Test
         id: test
         shell: bash
+        # cross is buggy with QEMU and slow
         if: matrix.job.use-cross == false
         run: make test
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,30 @@ env:
   INTERMEDIATES_DIR: intermediates
 
 jobs:
+  format:
+    name: Ensure 'cargo fmt' has been run
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        components: rustfmt
+    - uses: actions/checkout@v4
+    - run: cargo fmt -- --check
+
+  clippy:
+    name: Ensure 'cargo clippy' has no warnings
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        components: clippy
+    - uses: actions/checkout@v4
+    - run: cargo clippy --all-targets --all-features -- -Dwarnings
+
   build:
     name: ${{ matrix.job.os }}-${{ matrix.job.target }}
     runs-on: ${{ matrix.job.os }}
+    needs: [format, clippy]
     strategy:
       fail-fast: false
       matrix:
@@ -42,6 +63,7 @@ jobs:
       - name: Install prerequisites
         shell: bash
         run: |
+          # libudev and libusb not required anymore with native
           case ${{ matrix.job.target }} in
             *-linux-*) 
               sudo apt-get -y update;
@@ -49,41 +71,30 @@ jobs:
               sudo apt-get -y install libusb-1.0-0-dev;
               cargo install cargo-deb
               ;;
+            *)
+              ;;
+          esac
+
+      - name: Rustup add target
+        if: matrix.job.use-cross == false
+        shell: bash
+        run: |
+          case ${{ matrix.job.target }} in
             universal-apple-*)
               rustup target add x86_64-apple-darwin
               rustup target add aarch64-apple-darwin
               ;;
             *)
+              rustup target add ${{ matrix.job.target }}
               ;;
           esac
-
-      - name: Set cargo cmd
-        shell: bash
-        run: echo "CARGO_CMD=cargo" >> "$GITHUB_ENV"
-
-      - name: Rustup add target
-        if: matrix.job.use-cross == false && !startsWith(matrix.job.target, 'universal-apple')
-        shell: bash
-        run: rustup target add ${{ matrix.job.target }}
-
-      - name: Set cargo cmd to cross
-        shell: bash
-        if: matrix.job.use-cross == true
-        run: echo "CARGO_CMD=cross" >> "$GITHUB_ENV"
 
       - name: Install cross
         shell: bash
         if: matrix.job.use-cross == true
-        run: cargo install cross
-
-      - name: Format and clippy
-        id: format
-        shell: bash
-        if: matrix.job.use-cross == false
         run: |
-          cargo fmt -- --check
-          cargo clippy --all-targets -- -Dwarnings
-          cargo clippy --all-targets --all-features -- -Dwarnings
+          echo "CARGO_CMD=cross" >> "$GITHUB_ENV"
+          cargo install cross
 
       - name: Test
         id: test
@@ -138,7 +149,7 @@ jobs:
         shell: bash
         if: matrix.job.use-cross == false
         run: |
-          "${{ steps.prepare.outputs.BIN_PATH }}" --gen
+          make generated
           git diff --exit-code
 
       - name: Create tarball
@@ -220,7 +231,7 @@ jobs:
           echo "IS_RELEASE=${IS_RELEASE}" >> "$GITHUB_OUTPUT"
 
       - name: Publish archives and packages
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: steps.is-release.outputs.IS_RELEASE
         with:
           files: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
       matrix:
         job:
           # default features for all targets
-          - { os: ubuntu-latest, target: aarch64-unknown-linux-gnu, use-cross: true, feature-flags: "" }
+          - { os: ubuntu-24.04-arm, target: aarch64-unknown-linux-gnu, use-cross: false, feature-flags: "" }
           - { os: windows-latest, target: x86_64-pc-windows-gnu, use-cross: false, feature-flags: ""  }
           - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, use-cross: false, feature-flags: ""  }
           - { os: macos-latest, target: universal-apple-darwin, use-cross: false, feature-flags: ""  }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,20 +39,20 @@ jobs:
     - uses: actions/checkout@v4
     - run: cargo fmt -- --check
 
-  clippy:
-    name: Ensure 'cargo clippy' has no warnings
-    runs-on: ubuntu-latest
-    steps:
-    - uses: dtolnay/rust-toolchain@stable
-      with:
-        components: clippy
-    - uses: actions/checkout@v4
-    - run: cargo clippy --all-targets -- -Dwarnings
+  # clippy:
+  #   name: Ensure 'cargo clippy' has no warnings
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: dtolnay/rust-toolchain@stable
+  #     with:
+  #       components: clippy
+  #   - uses: actions/checkout@v4
+  #   - run: cargo clippy --all-targets -- -Dwarnings
 
   build:
     name: ${{ matrix.job.os }}-${{ matrix.job.target }}
     runs-on: ${{ matrix.job.os }}
-    needs: [format, clippy]
+    needs: [format]
     strategy:
       fail-fast: false
       matrix:
@@ -125,7 +125,11 @@ jobs:
         id: test
         shell: bash
         if: matrix.job.use-cross == false
-        run: cargo test --all-features
+        run: make test
+        env:
+          CARGO_FLAGS: ${{ matrix.job.feature-flags }}
+          CARGO_CMD: ${{ env.CARGO_CMD }}
+          TARGET: ${{ matrix.job.target }}
 
       - name: Generated files up to date
         id: generate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,6 +166,10 @@ jobs:
         if: contains(matrix.job.target, 'linux')
         run: |
           DPKG_PATH="$(make dpkg | tail -n1)"
+          # replace _ with -
+          DPKG_NAME="$(sed 's/_/-/g' <<< $(basename ${DPKG_PATH}))"
+          mv "${DPKG_PATH}" "$(dirname ${DPKG_PATH})/${DPKG_NAME}"
+          DPKG_PATH="$(dirname ${DPKG_PATH})/${DPKG_NAME}"
           echo "dpkg-${TARGET}=${DPKG_PATH}" >> "$GITHUB_OUTPUT"
           echo "DPKG_NAME=$(basename ${DPKG_PATH})" >> "$GITHUB_OUTPUT"
           echo "DPKG_PATH=${DPKG_PATH}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
   crate_metadata:
     name: Extract crate metadata
     runs-on: ubuntu-latest
+    if: github.event_name == 'release'
     steps:
     - uses: actions/checkout@v4
     - name: Extract crate information
@@ -76,18 +77,21 @@ jobs:
             ~/.cargo/git/db/
             ~/.cargo/bin/cargo-deb
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.job.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: dtolnay/rust-toolchain@stable
 
+      # Could remove this step if not clippy/testing --all-features as only required for non-native profiler
       - name: Install prerequisites
         shell: bash
         run: |
-          # libudev and libusb not required anymore with native
           case ${{ matrix.job.target }} in
             *-linux-*) 
               sudo apt-get -y update;
-              sudo apt-get -y install libudev-dev;
-              sudo apt-get -y install libusb-1.0-0-dev;
+              sudo apt-get -y install libudev-dev libusb-1.0-0-dev;
+              # install cargo-deb if not cached
+              if ! command -v cargo-deb &> /dev/null; then
+                cargo install cargo-deb
+              fi
               ;;
             *)
               ;;
@@ -129,7 +133,6 @@ jobs:
         run: make test
         env:
           CARGO_FLAGS: ${{ matrix.job.feature-flags }}
-          CARGO_CMD: ${{ env.CARGO_CMD }}
           TARGET: ${{ matrix.job.target }}
 
       - name: Generated files up to date
@@ -141,7 +144,6 @@ jobs:
           git diff --exit-code
         env:
           CARGO_FLAGS: ${{ matrix.job.feature-flags }}
-          CARGO_CMD: ${{ env.CARGO_CMD }}
           TARGET: ${{ matrix.job.target }}
 
       - name: Build release
@@ -150,7 +152,6 @@ jobs:
         run: echo "bin-${TARGET}=$(make release | tail -n1)" >> "$GITHUB_OUTPUT"
         env:
           CARGO_FLAGS: ${{ matrix.job.feature-flags }}
-          CARGO_CMD: ${{ env.CARGO_CMD }}
           TARGET: ${{ matrix.job.target }}
 
       - name: Create tarball
@@ -166,7 +167,6 @@ jobs:
           fi
         env:
           CARGO_FLAGS: ${{ matrix.job.feature-flags }}
-          CARGO_CMD: ${{ env.CARGO_CMD }}
           TARGET: ${{ matrix.job.target }}
 
       - name: Create Debian package
@@ -184,7 +184,6 @@ jobs:
           echo "DPKG_PATH=${DPKG_PATH}" >> "$GITHUB_OUTPUT"
         env:
           CARGO_FLAGS: ${{ matrix.job.feature-flags }}
-          CARGO_CMD: ${{ env.CARGO_CMD }}
           TARGET: ${{ matrix.job.target }}
 
       - name: Upload package artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,18 +2,33 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
   pull_request:
-  workflow_dispatch:
+  release:
+    types:
+      - created
 
 name: Test, build and package
-
-env:
-  PROJECT_NAME: cyme
-  INTERMEDIATES_DIR: intermediates
-
 jobs:
+  crate_metadata:
+    name: Extract crate metadata
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Extract crate information
+      id: crate_metadata
+      run: |
+        cargo metadata --no-deps --format-version 1 | jq -r '"name=" + .packages[0].version' | tee -a $GITHUB_OUTPUT
+        cargo metadata --no-deps --format-version 1 | jq -r '"version=" + .packages[0].version' | tee -a $GITHUB_OUTPUT
+        cargo metadata --no-deps --format-version 1 | jq -r '"maintainer=" + .packages[0].authors[0]' | tee -a $GITHUB_OUTPUT
+        cargo metadata --no-deps --format-version 1 | jq -r '"homepage=" + .packages[0].homepage' | tee -a $GITHUB_OUTPUT
+        cargo metadata --no-deps --format-version 1 | jq -r '"msrv=" + .packages[0].rust_version' | tee -a $GITHUB_OUTPUT
+    outputs:
+      name: ${{ steps.crate_metadata.outputs.name }}
+      version: ${{ steps.crate_metadata.outputs.version }}
+      maintainer: ${{ steps.crate_metadata.outputs.maintainer }}
+      homepage: ${{ steps.crate_metadata.outputs.homepage }}
+      msrv: ${{ steps.crate_metadata.outputs.msrv }}
+
   format:
     name: Ensure 'cargo fmt' has been run
     runs-on: ubuntu-latest
@@ -44,10 +59,15 @@ jobs:
         job:
           # default features for all targets
           - { os: ubuntu-latest, target: aarch64-unknown-linux-gnu, use-cross: true, feature-flags: "" }
-          # cli_generate for checking generated files up to date
-          - { os: windows-latest, target: x86_64-pc-windows-gnu, use-cross: false, feature-flags: "-F=cli_generate"  }
-          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, use-cross: false, feature-flags: "-F=cli_generate"  }
-          - { os: macos-latest, target: universal-apple-darwin, use-cross: false, feature-flags: "-F=cli_generate"  }
+          - { os: windows-latest, target: x86_64-pc-windows-gnu, use-cross: false, feature-flags: ""  }
+          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, use-cross: false, feature-flags: ""  }
+          - { os: macos-latest, target: universal-apple-darwin, use-cross: false, feature-flags: ""  }
+    outputs:
+      # pkg-linux-aarch64: ${{ steps.package.outputs.pkg-aarch64-unknown-linux-gnu }}
+      # pkg-linux-x86_64: ${{ steps.package.outputs.pkg-x86_64-unknown-linux-gnu }}
+      # pkg-windows-x86_64: ${{ steps.package.outputs.pkg-x86_64-pc-windows-gnu }}
+      # pkg-macos-x86_64: ${{ steps.package.outputs.pkg-universal-apple-darwin }}
+      homebrew-pkg-name: ${{ steps.package.outputs.MACOS_PKG_NAME }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
@@ -69,7 +89,6 @@ jobs:
               sudo apt-get -y update;
               sudo apt-get -y install libudev-dev;
               sudo apt-get -y install libusb-1.0-0-dev;
-              cargo install cargo-deb
               ;;
             *)
               ;;
@@ -100,49 +119,7 @@ jobs:
         id: test
         shell: bash
         if: matrix.job.use-cross == false
-        run: cargo test
-
-      - name: Build release
-        id: build
-        shell: bash
-        run: |
-          case ${{ matrix.job.target }} in
-            universal-apple-*) 
-              cargo build --locked --release ${{ matrix.job.feature-flags }} --target=aarch64-apple-darwin
-              cargo build --locked --release ${{ matrix.job.feature-flags }} --target=x86_64-apple-darwin
-              mkdir -p target/universal-apple-darwin/release
-              # merge into universal
-              lipo -create -output target/universal-apple-darwin/release/cyme target/aarch64-apple-darwin/release/cyme target/x86_64-apple-darwin/release/cyme
-              ;;
-            *) 
-              ${{ env.CARGO_CMD }} build --locked --release ${{ matrix.job.feature-flags }} --target=${{ matrix.job.target }}
-              ;;
-          esac
-
-      - name: Prepare and extract crate information
-        id: prepare
-        shell: bash
-        run: |
-          echo "PROJECT_VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n1)" >> "$GITHUB_ENV"
-          echo "PROJECT_MAINTAINER=$(sed -n 's/^authors = \["\(.*\)"\]/\1/p' Cargo.toml)" >> "$GITHUB_ENV"
-          echo "PROJECT_HOMEPAGE=$(sed -n 's/^homepage = "\(.*\)"/\1/p' Cargo.toml)" >> "$GITHUB_ENV"
-
-          # Figure out suffix of binary
-          EXE_SUFFIX=""
-          case ${{ matrix.job.target }} in
-            *-pc-windows-*) EXE_SUFFIX=".exe" ;;
-          esac;
-
-          # Setup paths
-          BIN_DIR="${{ env.INTERMEDIATES_DIR }}/release-bin"
-          mkdir -p "${BIN_DIR}"
-          BIN_NAME="${{ env.PROJECT_NAME }}${EXE_SUFFIX}"
-          BIN_PATH="${BIN_DIR}/${BIN_NAME}"
-
-          # Copy the release build binary to the result location
-          cp "target/${{ matrix.job.target }}/release/${BIN_NAME}" "${BIN_DIR}"
-          echo "BIN_PATH=${BIN_PATH}" >> "$GITHUB_OUTPUT"
-          echo "BIN_NAME=${BIN_NAME}" >> "$GITHUB_OUTPUT"
+        run: cargo test --all-features
 
       - name: Generated files up to date
         id: generate
@@ -152,63 +129,44 @@ jobs:
           make generated
           git diff --exit-code
 
+      - name: Build release
+        id: build
+        shell: bash
+        run: echo "bin-${TARGET}=$(make release | tail -n1)" >> "$GITHUB_OUTPUT"
+        env:
+          CARGO_FLAGS: ${{ matrix.job.feature-flags }}
+          CARGO_CMD: ${{ env.CARGO_CMD }}
+          TARGET: ${{ matrix.job.target }}
+
       - name: Create tarball
         id: package
         shell: bash
         run: |
-          PKG_SUFFIX=".tar.gz" ; case ${{ matrix.job.target }} in *-pc-windows-*) PKG_SUFFIX=".zip" ;; esac;
-
-          PKG_BASENAME=${PROJECT_NAME}-v${PROJECT_VERSION}-${{ matrix.job.target }}
-          PKG_NAME=${PKG_BASENAME}${PKG_SUFFIX}
-
-          echo "PKG_NAME=${PKG_NAME}" >> "$GITHUB_OUTPUT"
-
-          PKG_STAGING="${{ env.INTERMEDIATES_DIR }}/package"
-          ARCHIVE_DIR="${PKG_STAGING}/${PKG_BASENAME}/"
-          mkdir -p "${ARCHIVE_DIR}"
-
-          # Binary
-          cp "${{ steps.prepare.outputs.BIN_PATH }}" "$ARCHIVE_DIR"
-          # README, LICENSE, CHANGELOG
-          cp "README.md" "LICENSE" "CHANGELOG.md" "$ARCHIVE_DIR"
-          # Man page
-          cp 'doc/${{ env.PROJECT_NAME }}.1' "$ARCHIVE_DIR"
-          # Autocompletion files
-          mkdir -p autocomplete
-          cp 'doc/${{ env.PROJECT_NAME }}.fish' 'doc/${{ env.PROJECT_NAME }}.bash' 'doc/_${{ env.PROJECT_NAME }}' 'doc/_${{ env.PROJECT_NAME }}.ps1' autocomplete
-          cp -r autocomplete "${ARCHIVE_DIR}"
-          # base compressed package
-          pushd "${PKG_STAGING}/" >/dev/null
-          case ${{ matrix.job.target }} in
-            *-pc-windows-*) 7z -y a "${PKG_NAME}" "${PKG_BASENAME}"/* | tail -2 ;;
-            *) tar czf "${PKG_NAME}" "${PKG_BASENAME}"/* ;;
-          esac;
-          popd >/dev/null
-          # Let subsequent steps know where to find the compressed package
-          echo "PKG_PATH=${PKG_STAGING}/${PKG_NAME}" >> "$GITHUB_OUTPUT"
+          PKG_PATH="$(make package | tail -n1)"
+          echo "pkg-${TARGET}=${PKG_PATH}" >> "$GITHUB_OUTPUT"
+          echo "PKG_NAME=$(basename ${PKG_PATH})" >> "$GITHUB_OUTPUT"
+          echo "PKG_PATH=${PKG_PATH}" >> "$GITHUB_OUTPUT"
+          if [[ "${TARGET}" == *"apple"* ]]; then
+            echo "MACOS_PKG_NAME=$(basename ${PKG_PATH})" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          CARGO_FLAGS: ${{ matrix.job.feature-flags }}
+          CARGO_CMD: ${{ env.CARGO_CMD }}
+          TARGET: ${{ matrix.job.target }}
 
       - name: Create Debian package
         id: debian-package
         shell: bash
-        if: startsWith(matrix.job.os, 'ubuntu') && !contains(matrix.job.target, 'windows')
+        if: contains(matrix.job.target, 'linux')
         run: |
-          DPKG_STAGING="${{ env.INTERMEDIATES_DIR }}/debian-package"
-          DPKG_DIR="${DPKG_STAGING}/dpkg"
-          case ${{ matrix.job.target }} in
-            aarch64-*-linux-*) DPKG_ARCH=arm64 ;;
-            arm-*-linux-*hf) DPKG_ARCH=armhf ;;
-            i686-*-linux-*) DPKG_ARCH=i686 ;;
-            x86_64-*-linux-*) DPKG_ARCH=amd64 ;;
-          *) DPKG_ARCH=notset ;;
-          esac;
-
-          DPKG_NAME="${PROJECT_NAME}-v${PROJECT_VERSION}-1-${DPKG_ARCH}.deb"
-          echo "DPKG_NAME=${DPKG_NAME}" >> $GITHUB_OUTPUT
-          mkdir -p "${DPKG_DIR}"
-          DPKG_PATH="${DPKG_STAGING}/${DPKG_NAME}"
-          echo "DPKG_PATH=${DPKG_PATH}" >> $GITHUB_OUTPUT
-
-          cargo deb --target=${{ matrix.job.target }} --output "${DPKG_PATH}" --no-build --no-strip
+          DPKG_PATH="$(make dpkg | tail -n1)"
+          echo "dpkg-${TARGET}=${DPKG_PATH}" >> "$GITHUB_OUTPUT"
+          echo "DPKG_NAME=$(basename ${DPKG_PATH})" >> "$GITHUB_OUTPUT"
+          echo "DPKG_PATH=${DPKG_PATH}" >> "$GITHUB_OUTPUT"
+        env:
+          CARGO_FLAGS: ${{ matrix.job.feature-flags }}
+          CARGO_CMD: ${{ env.CARGO_CMD }}
+          TARGET: ${{ matrix.job.target }}
 
       - name: Upload package artifact
         uses: actions/upload-artifact@master
@@ -223,35 +181,33 @@ jobs:
           name: ${{ steps.debian-package.outputs.DPKG_NAME }}
           path: ${{ steps.debian-package.outputs.DPKG_PATH }}
 
-      - name: Check for release
-        id: is-release
-        shell: bash
-        run: |
-          unset IS_RELEASE ; if [[ $GITHUB_REF =~ ^refs/tags/v[0-9].* ]]; then IS_RELEASE='true' ; fi
-          echo "IS_RELEASE=${IS_RELEASE}" >> "$GITHUB_OUTPUT"
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [build, crate_metadata]
+    if: github.event_name == 'release'
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
 
-      - name: Publish archives and packages
+      - name: Upload release artifacts
         uses: softprops/action-gh-release@v2
-        if: steps.is-release.outputs.IS_RELEASE
         with:
           files: |
-            ${{ steps.package.outputs.PKG_PATH }}
-            ${{ steps.debian-package.outputs.DPKG_PATH }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Wait package uploaded
-        if: steps.is-release.outputs.IS_RELEASE && startsWith(matrix.job.target, 'universal-apple')
-        run: sleep 5 # sleep to ensure package is uploaded before homebrew
+            artifacts/**/*.tar.gz
+            artifacts/**/*.zip
+            artifacts/**/*.deb
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Bump Homebrew formula
         uses: mislav/bump-homebrew-formula-action@v3
-        if: steps.is-release.outputs.IS_RELEASE && startsWith(matrix.job.target, 'universal-apple')
         with:
           formula-name: cyme
           formula-path: Formula/cyme.rb
           homebrew-tap: tuna-f1sh/homebrew-taps
-          download-url: https://github.com/tuna-f1sh/cyme/releases/download/v${{ env.PROJECT_VERSION}}/${{ steps.package.outputs.PKG_NAME }}
+          download-url: https://github.com/tuna-f1sh/cyme/releases/download/v${{ needs.crate_metadata.outputs.version }}/${{ needs.build.outputs.homebrew-pkg-name }}
           commit-message: |
             {{formulaName}} {{version}}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased]
+
+`cyme watch` subcommand to watch for USB device hotplug events and _live_ edit display settings. A simple TUI proof of concept that grew beyond just showing hotplug events into something quite handy for exploring enumerated devices. It can also edit display settings and save them to the cyme config file. 
+
+It's a nice way to customise display blocks: press 'b' to use the editor and 'Ctrl-s' to save. Use '?' for other keybindings. Navigation is mostly Vim-like. Try connecting and disconnecting a device while running `cyme watch` to see the hotplug events.
+
+The interface is simplistic at the moment but could be re-skinned with something like Ratatui in the future.
+
+### Added
+
+- `cyme watch` subcommand to watch for USB device hotplug events and 'live' edit display settings ([#58](https://github.com/tuna-f1sh/cyme/pull/58))
+
 ## [2.1.3] - 2024-04-03
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ version = "2.1.3"
 edition = "2021"
 keywords = ["usb", "lsusb", "system_profiler", "macos", "libusb"]
 categories = ["command-line-utilities"]
-exclude = [".github"]
+exclude = [".github", "scripts"]
 
 [dependencies]
 clap = { version = "4.0.22", features = ["derive", "wrap_help"] } # CLI argument parsing

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,46 @@
-PROJECT_NAME := $(shell grep -m 1 name Cargo.toml | cut -d '"' -f 2)
-RELEASE_BIN := $(CARGO_TARGET_DIR)/release/$(PROJECT_NAME)
+PROJECT_NAME := $(shell cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].name')
 VERSION := $(shell cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+OS := $(shell uname)
 
 RSRCS += $(wildcard src/*.rs src/**/*.rs)
-CARGO_TARGET_DIR ?= target
-CARGO_RELEASE_FLAGS += --locked --release
-DOCS = doc/_$(PROJECT_NAME) doc/$(PROJECT_NAME).1 doc/$(PROJECT_NAME).bash doc/$(PROJECT_NAME).fish doc/$(PROJECT_NAME).ps1 doc/cyme_example_config.json
+DOCS = $(AUTOCOMPLETE_FILES) doc/$(PROJECT_NAME).1  doc/cyme_example_config.json
+AUTOCOMPLETE_FILES = doc/_$(PROJECT_NAME) doc/$(PROJECT_NAME).bash doc/$(PROJECT_NAME).fish doc/_$(PROJECT_NAME).ps1
 
-OS := $(shell uname)
+# ?= allows overriding from command line with 'cross'
+CARGO_CMD ?= cargo
+CARGO_TARGET_DIR ?= target
+PACKAGE_DIR ?= $(CARGO_TARGET_DIR)/packages
+CARGO_RELEASE_FLAGS += --locked --release
+
+ifeq ($(TARGET),)
+	PACKAGE_BASE := $(PROJECT_NAME)-v$(VERSION)-$(OS)
+	TARGET_DIR := $(CARGO_TARGET_DIR)
+else
+	PACKAGE_BASE := $(PROJECT_NAME)-v$(VERSION)-$(TARGET)
+	TARGET_DIR := $(CARGO_TARGET_DIR)/$(TARGET)
+	CARGO_RELEASE_FLAGS += --target $(TARGET)
+endif
+RELEASE_BIN := $(TARGET_DIR)/release/$(PROJECT_NAME)
+
+ifeq ($(findstring windows,$(TARGET)),windows)
+	ARCHIVE_EXT := zip
+else
+	ARCHIVE_EXT := tar.gz
+endif
+ARCHIVE := $(PACKAGE_DIR)/$(PACKAGE_BASE).$(ARCHIVE_EXT)
 
 ifeq ($(OS), Darwin)
 	PREFIX ?= /usr/local
 else
 	PREFIX ?= /usr
 endif
+
 BIN_PATH ?= $(PREFIX)/bin
 BASH_COMPLETION_PATH ?= $(PREFIX)/share/bash-completion/completions
 ZSH_COMPLETION_PATH ?= $(PREFIX)/share/zsh/site-functions
 MAN_PAGE_PATH ?= $(PREFIX)/share/man/man1
 
-.PHONY: release install generated enter_version new_version test
+.PHONY: release install generated enter_version new_version test package
 
 release: $(RELEASE_BIN)
 
@@ -42,17 +63,46 @@ enter_version:
 	@read new_version; \
 	sed -i "s/^version = .*/version = \"$$new_version\"/" Cargo.toml
 	# update because Cargo.lock references self for tests
-	cargo update
+	$(CARGO_CMD) update
 
 new_version: enter_version generated
 
 test:
-	cargo test $(CARGO_TEST_FLAGS)
+	$(CARGO_CMD) test $(CARGO_TEST_FLAGS)
 
-$(RELEASE_BIN): Cargo.lock $(RSRCS)
-	@echo "Building version $(PROJECT_NAME) $(VERSION)"
-	cargo build $(CARGO_RELEASE_FLAGS)
+package: $(ARCHIVE)
+	@echo "$(ARCHIVE)"
 
 $(DOCS): Cargo.toml $(RSRCS)
 	@echo "Generating docs for $(PROJECT_NAME) $(VERSION)"
-	cargo run -F=cli_generate -- --gen
+	$(CARGO_CMD) run --locked --release -F=cli_generate -- --gen
+
+$(RELEASE_BIN): Cargo.lock $(RSRCS)
+ifeq ($(TARGET),universal-apple-darwin)
+	cargo build --target aarch64-apple-darwin $(CARGO_RELEASE_FLAGS)
+	cargo build --target x86_64-apple-darwin $(CARGO_RELEASE_FLAGS)
+	mkdir -p $(shell dirname $(RELEASE_BIN))
+	lipo -create -output $(RELEASE_BIN) \
+	  $(CARGO_TARGET_DIR)/aarch64-apple-darwin/release/$(PROJECT_NAME) \
+	  $(CARGO_TARGET_DIR)/x86_64-apple-darwin/release/$(PROJECT_NAME)
+else
+	$(CARGO_CMD) build --target $(TARGET) $(CARGO_RELEASE_FLAGS)
+endif
+	@echo "$(RELEASE_BIN)"
+
+$(ARCHIVE): $(RELEASE_BIN) README.md LICENSE CHANGELOG.md $(DOCS)
+	mkdir -p $(PACKAGE_DIR)/$(PACKAGE_BASE)
+	cp $(RELEASE_BIN) $(PACKAGE_DIR)/$(PACKAGE_BASE)/
+	cp README.md LICENSE CHANGELOG.md $(PACKAGE_DIR)/$(PACKAGE_BASE)/
+	cp 'doc/$(PROJECT_NAME).1' $(PACKAGE_DIR)/$(PACKAGE_BASE)/
+	mkdir -p $(PACKAGE_DIR)/$(PACKAGE_BASE)/autocomplete
+	cp $(AUTOCOMPLETE_FILES) $(PACKAGE_DIR)/$(PACKAGE_BASE)/autocomplete/
+ifeq ($(ARCHIVE_EXT),zip)
+	cd $(PACKAGE_DIR) && zip -r $(PACKAGE_BASE).zip $(PACKAGE_BASE)
+else
+	cd $(PACKAGE_DIR) && tar czf $(PACKAGE_BASE).tar.gz $(PACKAGE_BASE)
+endif
+	rm -rf $(PACKAGE_DIR)/$(PACKAGE_BASE)
+
+%.deb:
+	cargo deb --target $(TARGET) --no-strip --no-build --output $@

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ DOCS = $(AUTOCOMPLETES) doc/$(PROJECT_NAME).1  doc/cyme_example_config.json
 CARGO_CMD ?= cargo
 CARGO_TARGET_DIR ?= target
 PACKAGE_DIR ?= $(CARGO_TARGET_DIR)/packages
-CARGO_FLAGS += --locked --release
+CARGO_FLAGS += --locked
 
 ifeq ($(TARGET),)
 	PACKAGE_BASE := $(PROJECT_NAME)-v$(VERSION)-$(OS)
@@ -77,7 +77,9 @@ enter_version:
 new_version: test enter_version gen
 
 test:
-	$(CARGO_CMD) test $(CARGO_TEST_FLAGS)
+	$(CARGO_CMD) test $(CARGO_FLAGS) $(CARGO_TEST_FLAGS)
+	# test with libusb profiler
+	$(CARGO_CMD) test $(CARGO_FLAGS) $(CARGO_TEST_FLAGS) --no-default-features -F=ffi
 
 package: $(ARCHIVE)
 	@echo "$(ARCHIVE)"
@@ -96,14 +98,14 @@ $(DOCS): Cargo.toml $(RSRCS)
 
 $(RELEASE_BIN): Cargo.lock $(RSRCS)
 ifeq ($(TARGET),universal-apple-darwin)
-	cargo build --target aarch64-apple-darwin $(CARGO_FLAGS)
-	cargo build --target x86_64-apple-darwin $(CARGO_FLAGS)
+	cargo build --target aarch64-apple-darwin $(CARGO_FLAGS) --release
+	cargo build --target x86_64-apple-darwin $(CARGO_FLAGS) --release
 	mkdir -p $(shell dirname $(RELEASE_BIN))
 	lipo -create -output $(RELEASE_BIN) \
 	  $(CARGO_TARGET_DIR)/aarch64-apple-darwin/release/$(PROJECT_NAME) \
 	  $(CARGO_TARGET_DIR)/x86_64-apple-darwin/release/$(PROJECT_NAME)
 else
-	$(CARGO_CMD) build $(CARGO_FLAGS)
+	$(CARGO_CMD) build $(CARGO_FLAGS) --release
 endif
 
 $(ARCHIVE): $(RELEASE_BIN) README.md LICENSE CHANGELOG.md $(DOCS)

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,9 @@ ifeq ($(TARGET),)
 else
 	PACKAGE_BASE := $(PROJECT_NAME)-v$(VERSION)-$(TARGET)
 	TARGET_DIR := $(CARGO_TARGET_DIR)/$(TARGET)
+ifneq ($(TARGET),universal-apple-darwin)
 	CARGO_FLAGS += --target $(TARGET)
+endif
 endif
 RELEASE_BIN := $(TARGET_DIR)/release/$(PROJECT_NAME)
 
@@ -86,7 +88,7 @@ dpkg: $(RELEASE_BIN)
 
 $(DOCS): Cargo.toml $(RSRCS)
 	@echo "Generating docs for $(PROJECT_NAME) $(VERSION)"
-	$(CARGO_CMD) run --locked --release -F=cli_generate -- --gen
+	$(CARGO_CMD) run $(CARGO_FLAGS) -F=cli_generate -- --gen
 
 $(RELEASE_BIN): Cargo.lock $(RSRCS)
 ifeq ($(TARGET),universal-apple-darwin)

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ $(ARCHIVE): $(RELEASE_BIN) README.md LICENSE CHANGELOG.md $(DOCS)
 	mkdir -p $(PACKAGE_DIR)/$(PACKAGE_BASE)/autocomplete
 	cp $(AUTOCOMPLETES) $(PACKAGE_DIR)/$(PACKAGE_BASE)/autocomplete/
 ifeq ($(ARCHIVE_EXT),zip)
-	cd $(PACKAGE_DIR) && zip -r $(PACKAGE_BASE).zip $(PACKAGE_BASE)
+	cd $(PACKAGE_DIR) && 7z -y a $(PACKAGE_BASE).zip $(PACKAGE_BASE)
 else
 	cd $(PACKAGE_DIR) && tar czf $(PACKAGE_BASE).tar.gz $(PACKAGE_BASE)
 endif

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ BASH_COMPLETION_PATH ?= $(PREFIX)/share/bash-completion/completions
 ZSH_COMPLETION_PATH ?= $(PREFIX)/share/zsh/site-functions
 MAN_PAGE_PATH ?= $(PREFIX)/share/man/man1
 
-.PHONY: release install clean generated docs gen enter_version new_version test package dpkg
+.PHONY: release install clean generated docs gen enter_version new_version release_version test package dpkg
 
 release: $(RELEASE_BIN)
 	@echo "$(RELEASE_BIN)"
@@ -75,6 +75,9 @@ enter_version:
 	$(CARGO_CMD) update
 
 new_version: test enter_version gen
+
+release_version:
+	@exec scripts/release_version.sh
 
 test:
 	$(CARGO_CMD) test $(CARGO_FLAGS) $(CARGO_TEST_FLAGS)

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,11 @@ package: $(ARCHIVE)
 
 dpkg: $(RELEASE_BIN)
 	cargo install cargo-deb
+ifeq ($(TARGET),)
 	cargo deb --no-strip --no-build
+else
+	cargo deb --target $(TARGET) --no-strip --no-build
+endif
 
 $(DOCS): Cargo.toml $(RSRCS)
 	@echo "Generating docs for $(PROJECT_NAME) $(VERSION)"
@@ -117,4 +121,8 @@ endif
 	rm -rf $(PACKAGE_DIR)/$(PACKAGE_BASE)
 
 %.deb:
+ifeq ($(TARGET),)
+	cargo deb --no-strip --no-build --output $@
+else
 	cargo deb --target $(TARGET) --no-strip --no-build --output $@
+endif

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,6 @@ package: $(ARCHIVE)
 	@echo "$(ARCHIVE)"
 
 dpkg: $(RELEASE_BIN)
-	cargo install cargo-deb
 ifeq ($(TARGET),)
 	cargo deb --no-strip --no-build
 else

--- a/scripts/release_version.sh
+++ b/scripts/release_version.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[0].version')"
+DATE="$(date +%Y-%m-%d)"
+
+echo "Preparing release version $VERSION"
+
+# Check if the version is already in the changelog
+if git rev-parse -q --verify "v$VERSION" >/dev/null 2>&1; then
+  echo "Error: git tag v$VERSION already exists! Aborting."
+  exit 1
+fi
+
+# Extract the changes text for this version
+CHANGELOG_CONTENT="$(
+  awk "/^## \\[$VERSION\\]/ {found=1; next} /^## \\[/ {found=0} found" CHANGELOG.md
+)"
+
+if [ -z "$(echo "$CHANGELOG_CONTENT" | sed 's/^[[:space:]]*\$//')" ]; then
+  echo "Error: No content found for version $VERSION in CHANGELOG.md!"
+  exit 1
+fi
+
+echo "Changelog content for version $VERSION:"
+echo "$CHANGELOG_CONTENT"
+
+# Change to version and date if Unreleased
+if ! grep -qE "^## \\[$VERSION\\]" CHANGELOG.md; then
+  if grep -qE "^## \\[Unreleased\\]" CHANGELOG.md; then
+    echo "Renaming [Unreleased] to [$VERSION] - $DATE"
+    sed -i "s/^## \\[Unreleased\\]/## [$VERSION] - $DATE/" CHANGELOG.md
+  else
+    echo "Error: No '## [Unreleased]' or '## [$VERSION]' heading found in CHANGELOG.md."
+    exit 1
+  fi
+fi
+
+
+echo "Creating signed git tag v$VERSION"
+echo "$CHANGELOG_CONTENT" | git tag -a "v$VERSION" -F -
+
+echo "Tag v$VERSION created."
+
+# Check to continue
+read -r -p "Tag v$VERSION created locally. Push tag to origin? [y/N] " answer
+case "$answer" in
+  [Yy]* )
+    echo "Pushing tag v$VERSION to origin..."
+    git push origin "v$VERSION"
+    ;;
+  * )
+    echo "Skipping tag push."
+    exit 0
+    ;;
+esac
+
+read -r -p "Create GitHub release with 'gh release create v$VERSION --notes-from-tag'? [y/N] " answer
+case "$answer" in
+  [Yy]* )
+    echo "Creating GitHub release from tag..."
+    gh release create "v$VERSION" --notes-from-tag --verify-tag --title "v$VERSION"
+    ;;
+  * )
+    echo "Skipping GitHub release creation."
+    ;;
+esac


### PR DESCRIPTION
* Split format check into pre-build as only required once for all targets.
* Same could be said for `cargo clippy`. There is OS specific code however and the legacy libusb support requires libusb and udev. Keep this inside the matrix build for now because of this.
* Makefile used as the targets. Nice not only because can reproduce outside action but also because they are only run if the dependencies are newer than existing: `make generate` for example.
* Would be nice in future to remove cargo-deb in favour of a local script - seems overkill to install this. Tried to optimise however by caching this bin.
* Change release process to manual but run action on release to attach artefacts. I prefer to do it manually as need to attach CHANGELOG anyway the tagged auto-release isn't that helpful.