### PR TITLE
feat: --json stream for watch #65

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -727,7 +727,11 @@ fn cyme() -> Result<()> {
 
     #[cfg(feature = "watch")]
     if matches!(args.command, Some(SubCommand::Watch)) {
-        watch::watch_usb_devices(spusb, filter, settings, config)?;
+        if args.json {
+            watch::watch_usb_devices_json(spusb, filter, settings)?;
+        } else {
+            watch::watch_usb_devices(spusb, filter, settings, config)?;
+        }
         return Ok(());
     }
 

--- a/src/profiler/types.rs
+++ b/src/profiler/types.rs
@@ -1133,6 +1133,7 @@ impl FromStr for DeviceSpeed {
 
 /// Events used by the watch feature
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum DeviceEvent {
     /// Device profiled at time
     Profiled(chrono::DateTime<chrono::Local>),


### PR DESCRIPTION
Adds `--json` output functionality to `watch` subcommand. Streams '\n' separated json dump of system USB profiling with each hot plug event.

I feel like a IPC protocol would be better for sharing between processes but this is a easy addition for using cyme within code.

Some `jq` filtering examples:

## Just show name and event

`cargo run -- --json watch | jq '.buses[] | .devices[]? | {name, last_event}'`

## Filter only hot-plug events and dump changed device

```
jq '
  .buses[] | .devices[]?
  | select(
      (.last_event | has("Connected")) or
      (.last_event | has("Disconnected"))
    )
'
```

Closes #65