### PR TITLE
fix: watch assign bus based on windows bus_id #67

### DIFF
--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -920,6 +920,7 @@ mod platform {
                 pci_vendor: Some(pci_info.vendor_id),
                 pci_device: Some(pci_info.product_id),
                 pci_revision: Some(pci_info.revision),
+                id: bus.bus_id().to_string(),
                 ..Default::default()
             }
         } else {
@@ -927,6 +928,7 @@ mod platform {
                 usb_bus_number: None,
                 name: bus.system_name().map(|s| s.to_string()).unwrap_or_default(),
                 host_controller: bus.parent_instance_id().to_string_lossy().to_string(),
+                id: bus.bus_id().to_string(),
                 ..Default::default()
             }
         }

--- a/src/profiler/types.rs
+++ b/src/profiler/types.rs
@@ -365,6 +365,10 @@ pub struct Bus {
     /// On Linux, the root hub is also included in this list
     #[serde(rename(deserialize = "_items"), alias = "devices")]
     pub devices: Option<Vec<Device>>,
+    /// Bus ID is a string on Windows and required to match inserted devices after profiling
+    #[cfg(all(target_os = "windows", feature = "nusb"))]
+    #[serde(skip)]
+    pub id: String,
     /// Internal data for tracking events and other data
     #[serde(skip)]
     pub(crate) internal: InternalData,


### PR DESCRIPTION
Windows nusb::Device don't have a bus number but a bus_id String. cyme generates the bus number during profiling on order profiled for each bus. Looking up bus number for a Windows nusb::Device won't work.

Instead to add a device post profiling, we need to store the bus_id as Bus.id on Windows (since only needed on this target) such we can check against the nusb::Device.bus_id and get the cyme assign int number.

Adding this int bus number to the newly connected device means that the insert() will correctly will correctly assign to the correct bus and/or replace any existing device at that port_path.