### PR TITLE
Fix MaxPower for USB3 and later

### DIFF
--- a/src/profiler/libusb.rs
+++ b/src/profiler/libusb.rs
@@ -367,6 +367,14 @@ impl LibUsbProfiler {
                 None
             };
 
+            // The rusb crate multiplies the raw MaxPower value by 2, which is not correct
+            // for USB3 and later, so we need to multiply by 4 to get the correct number.
+            let power_mult = if device_desc.usb_version().0 >= 3 {
+                4
+            } else {
+                1
+            };
+
             ret.push(usb::Configuration {
                 name: config_desc
                     .description_string_index()
@@ -377,7 +385,7 @@ impl LibUsbProfiler {
                 number: config_desc.number(),
                 attributes,
                 max_power: NumericalUnit {
-                    value: config_desc.max_power() as u32,
+                    value: config_desc.max_power() as u32 * power_mult,
                     unit: String::from("mA"),
                     description: None,
                 },


### PR DESCRIPTION
For Configuration descriptors for USB3 and later, the MaxPower value is supplied in 8mA units, while earlier versions used 2mA units.

Update nusb and libusb code to account for this.