### PR TITLE
nusb: fix configuration descriptor length

### DIFF
--- a/src/profiler/nusb.rs
+++ b/src/profiler/nusb.rs
@@ -499,7 +499,7 @@ impl NusbProfiler {
                     unit: String::from("mA"),
                     description: None,
                 },
-                length: config_desc.len() as u8,
+                length: config_desc[0],
                 total_length,
                 interfaces: self.build_interfaces(device, &c)?,
                 extra: self


### PR DESCRIPTION
NusbProfiler currently return the wTotalLength value for both bLength and wTotalLength.

For bLength, use the first element in the configuration descriptor, which holds the actual bLength value.