### PR TITLE
Display correct number of interfaces for multiple alt settings

### DIFF
--- a/src/lsusb.rs
+++ b/src/lsusb.rs
@@ -551,7 +551,7 @@ fn dump_config(config: &Configuration, indent: usize) {
         LSUSB_DUMP_WIDTH,
     );
     dump_value(
-        config.num_interfaces,
+        config.number_of_interfaces(),
         "bNumInterfaces",
         indent + 2,
         LSUSB_DUMP_WIDTH,

--- a/src/profiler/libusb.rs
+++ b/src/profiler/libusb.rs
@@ -391,7 +391,7 @@ impl LibUsbProfiler {
                 },
                 length: config_desc.length(),
                 total_length: config_desc.total_length(),
-                num_interfaces: config_desc.num_interfaces(),
+                num_interfaces: Some(config_desc.num_interfaces()),
                 interfaces: self.build_interfaces(handle, &config_desc)?,
                 extra: self
                     .build_config_descriptor_extra(handle, config_desc.extra().to_vec())

--- a/src/profiler/nusb.rs
+++ b/src/profiler/nusb.rs
@@ -512,7 +512,7 @@ impl NusbProfiler {
                 },
                 length: config_desc[0],
                 total_length,
-                num_interfaces: c.num_interfaces(),
+                num_interfaces: Some(c.num_interfaces()),
                 interfaces: self.build_interfaces(device, &c)?,
                 extra: self
                     .build_config_descriptor_extra(device, config_extra)

--- a/tests/data/cyme_libusb_linux_tree.json
+++ b/tests/data/cyme_libusb_linux_tree.json
@@ -40,6 +40,7 @@
                 "name": "",
                 "string_index": 0,
                 "number": 1,
+                "num_interfaces": null,
                 "interfaces": [
                   {
                     "name": "",
@@ -124,6 +125,7 @@
                 "name": "Parallels",
                 "string_index": 1,
                 "number": 1,
+                "num_interfaces": null,
                 "interfaces": [
                   {
                     "name": "Absolute Coordinate Interface",
@@ -239,6 +241,7 @@
                 "name": "Parallels",
                 "string_index": 1,
                 "number": 1,
+                "num_interfaces": null,
                 "interfaces": [
                   {
                     "name": "Virtual USB Printer Interface",
@@ -330,6 +333,7 @@
                 "name": "",
                 "string_index": 0,
                 "number": 1,
+                "num_interfaces": null,
                 "interfaces": [
                   {
                     "name": "",
@@ -432,6 +436,7 @@
                     "name": "Configuration",
                     "string_index": 4,
                     "number": 1,
+                    "num_interfaces": null,
                     "interfaces": [
                       {
                         "name": "CDC",
@@ -688,6 +693,7 @@
                     "name": "",
                     "string_index": 0,
                     "number": 1,
+                    "num_interfaces": null,
                     "interfaces": [
                       {
                         "name": "Black Magic GDB Server",
@@ -928,6 +934,7 @@
                 "name": "",
                 "string_index": 0,
                 "number": 1,
+                "num_interfaces": null,
                 "interfaces": [
                   {
                     "name": "",
@@ -1019,6 +1026,7 @@
                 "name": "",
                 "string_index": 0,
                 "number": 1,
+                "num_interfaces": null,
                 "interfaces": [
                   {
                     "name": "",
@@ -1111,6 +1119,7 @@
                 "name": "",
                 "string_index": 0,
                 "number": 1,
+                "num_interfaces": null,
                 "interfaces": [
                   {
                     "name": "",


### PR DESCRIPTION
Currently, the bNumInterfaces field of the configuration descriptors is wrong when there are multiple alt setting in one or more interfaces.

This probably happens because config.interfaces includes one object per alt setting.

Use the raw bNumInterfaces from the configuration descriptor instead of using config.interfaces.len().


To make the tests, I had to mark `bNumInterfaces` as `serde(skip)`. I am not sure what is your preferred way to handle this. I have marked this PR draft for now, until this is resolved.