### PR TITLE
profiler: fix bugs effecting performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1082,18 +1082,18 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.104"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9695f8df41bb4f3d222c95a67532365f569318332d03d5f3f67f37b20e6ebdf0"
+checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
 dependencies = [
  "proc-macro2",
 ]
@@ -1291,9 +1291,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.148"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3084b546a1dd6289475996f182a22aba973866ea8e8b02c51d9f46b1336a22da"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
@@ -1430,9 +1430,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.113"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678faa00651c9eb72dd2020cbdf275d92eccb2400d568e419efdd64838145cb4"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1981,18 +1981,18 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.31"
+version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
+checksum = "1fabae64378cb18147bb18bca364e63bdbe72a0ffe4adf0addfec8aa166b2c56"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.31"
+version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
+checksum = "c9c2d862265a8bb4471d87e033e730f536e2a285cc7cb05dbce09a2a97075f90"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2001,6 +2001,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.10"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e0d8dffbae3d840f64bda38e28391faef673a7b5a6017840f2a106c8145868"
+checksum = "2fc5a66a20078bf1251bde995aa2fdcc4b800c70b5d92dd2c62abc5c60f679f8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ colored = "3.0.0" # terminal colouring helper
 cansi = { version = "=2.2.1", optional = true } # ANSI escape code helper; decolored - no dependencies
 itertools = "0.10.5" # iterator methods used for building device tree
 rusb = { version = "0.9.4", optional = true } # libusb bindings
-nusb = { version = "0.2.0", optional = true } # pure Rust USB library
+nusb = { version = "0.2.1", optional = true } # pure Rust USB library
 serde = { version = "1.0", features = ["derive"] } # --json serialisation and --from-json deserialisation
 serde_json = "1.0.87"
 serde_with = "2.0.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -435,7 +435,7 @@ fn get_system_profile(config: &Config, args: &Args) -> Result<profiler::SystemPr
         || args.device.is_some()
         || config.lsusb
         || config.more
-        || args.filter_class.is_none()
+        || args.filter_class.is_some()
     // class filter requires extra
     {
         profiler::get_spusb_with_extra()

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -632,7 +632,11 @@ where
     fn get_spusb(&mut self, with_extra: bool) -> Result<SystemProfile> {
         let mut spusb = SystemProfile { buses: Vec::new() };
 
-        log::info!("Building SystemProfile with {self:?}");
+        if with_extra {
+            log::info!("Building SystemProfile using {self:?} with extra device data");
+        } else {
+            log::info!("Building SystemProfile using {self:?} without extra device data");
+        }
 
         // temporary store of devices created when iterating through DeviceList
         let mut cache = self.get_devices(with_extra)?;
@@ -812,7 +816,7 @@ pub fn get_spusb() -> Result<SystemProfile> {
     #[cfg(feature = "nusb")]
     {
         let mut profiler = nusb::NusbProfiler::new();
-        profiler.get_spusb(true)
+        profiler.get_spusb(false)
     }
 
     #[cfg(all(not(feature = "libusb"), not(feature = "nusb")))]

--- a/src/profiler/libusb.rs
+++ b/src/profiler/libusb.rs
@@ -490,7 +490,12 @@ impl LibUsbProfiler {
         device: &libusb::Device<T>,
         device_desc: &libusb::DeviceDescriptor,
     ) -> Result<UsbDevice<T>> {
-        let timeout = std::time::Duration::from_secs(1);
+        let timeout = std::time::Duration::from_millis(
+            std::env::var("CYME_USB_TIMEOUT_MS")
+                .ok()
+                .and_then(|s| s.parse::<u64>().ok())
+                .unwrap_or(200),
+        );
         let handle = device.open()?;
         let language = match handle.read_languages(timeout) {
             Ok(l) => {

--- a/src/profiler/nusb.rs
+++ b/src/profiler/nusb.rs
@@ -691,7 +691,13 @@ impl NusbProfiler {
                         language,
                         vidpid: (device_info.vendor_id(), device_info.product_id()),
                         location: sp_device.location_id.to_owned(),
-                        timeout: std::time::Duration::from_secs(1),
+                        // timeout from CYME_USB_TIMEOUT_MS or default 200ms
+                        timeout: std::time::Duration::from_millis(
+                            std::env::var("CYME_USB_TIMEOUT_MS")
+                                .ok()
+                                .and_then(|s| s.parse::<u64>().ok())
+                                .unwrap_or(200),
+                        ),
                     };
 
                     match self.build_spdevice_extra(&usb_device, &mut sp_device) {


### PR DESCRIPTION
I noticed profiling was slow on hosts with more than a few devices, even for the default, non-verbose display. It mostly occured on macOS but Linux also felt slower.

Using macOS `log`, I noticed timeouts during control requests - often due to interface already claimed. I also noticed the profiler was getting all the device descriptor data (extra) even when it was not required. This was due to a couple of silly bugs:

* is_none() rather than is_some() for the filter_class arg in the check to use get_spusb_with_extra. The filter_class should not have worked due to this, if not for the following bug...
* `true` passed to profiler.get_spusb to get extra using nusb within plain get_spusb; it should have been `false`. Effectively, extra was always obtained with nusb profiler due to this!

Additionally, I felt the default USB control timeout was too long so reduced it from 1000 ms to 200 ms. There is a env CYME_USB_TIMEOUT_MS to override this.

Time for `cyme` (non-verbose, 5 devices a couple of hubs) to print with the fixes improved by a factor of ~6: ~40 ms to 6.5 ms.

Hosts with many devices and hubs should see a greater improvement for both non-verbose and verbose printing.