### PR TITLE
feat: --exclude KEY=VALUE flag and multi-value --vidpid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+* arg: `--vidpid`/`-d` now accepts multiple values (repeat the flag or use a
+  comma-separated list) to match any of several devices.
+* arg: `--exclude KEY=VALUE` flag to exclude devices from output. Supported
+  keys: `vidpid`, `name`, `serial`, `class`. Composes with include filters,
+  e.g. `cyme -d 0x05ac: --exclude vidpid=05ac:8600`.
+* profiler: `Filter` now exposes `exclude_vidpid`, `exclude_name`,
+  `exclude_serial`, `exclude_class` fields and an `is_excluded` helper.
+  Exclusion is applied in both `is_match` and `is_potential_match`, so
+  profilers can prune excluded devices without loading extras when the
+  decision is authoritative (e.g. vidpid, or base class).
+
+### Changed
+
+* **BREAKING** (library): `Filter::vid: Option<u16>` and
+  `Filter::pid: Option<u16>` are replaced by
+  `Filter::vidpid: Vec<(Option<u16>, Option<u16>)>`. Each entry is a
+  `(vid, pid)` pair where either side may be `None` to match anything;
+  multiple entries combine with OR semantics. An empty `Vec` disables
+  the filter. Migration:
+
+  ```rust
+  // before
+  Filter { vid: Some(0x1d50), pid: Some(0x6018), ..Default::default() }
+  // after
+  Filter { vidpid: vec![(Some(0x1d50), Some(0x6018))], ..Default::default() }
+  ```
+
+### Fixed
+
+* arg: `parse_vidpid` previously parsed each half as `u32` and cast `as u16`,
+  silently wrapping values larger than `0xFFFF` (e.g. `0x10000:0x1` became
+  `(0x0, 0x1)`). Values that overflow `u16` now return a parse error.
+
 ## [2.3.0] - 2025-03-29
 
 Big reduction of profiling time^ when filtering by passing options with filter to profiler. Previously, filtering was done post profiling of all devices - even those that would be filtered out. This included opening descriptors and reading data for redundant devices.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,14 @@ cyme -d 0x05ac
 cyme -d 05ac:8103 --mask-serials hide
 # Filter for only devices with a certain name and class (filters can be combined)
 cyme --filter-name "Black Magic" --filter-class cdc-data
+# Match multiple vid:pid pairs (repeat the flag and/or use a comma list)
+cyme -d 1d50:6018 -d 0x05ac:
+cyme -d 1d50:6018,0x05ac:
+# Exclude devices; supported keys: vidpid, name, serial, class
+cyme --exclude vidpid=1d50:6018
+cyme --exclude vidpid=1d50:6018,name=Hub
+# Show all Apple devices except one specific product
+cyme -d 0x05ac: --exclude vidpid=05ac:8600
 ```
 
 ### JSON - jq

--- a/doc/_cyme
+++ b/doc/_cyme
@@ -15,8 +15,8 @@ _cyme() {
 
     local context curcontext="$curcontext" state line
     _arguments "${_arguments_options[@]}" : \
-'-d+[Show only devices with the specified vendor and product ID numbers (in hexadecimal) in format VID\:\[PID\]]:VIDPID:_default' \
-'--vidpid=[Show only devices with the specified vendor and product ID numbers (in hexadecimal) in format VID\:\[PID\]]:VIDPID:_default' \
+'*-d+[Show only devices with the specified vendor and product ID numbers (in hexadecimal) in format VID\:\[PID\]]:VIDPID:_default' \
+'*--vidpid=[Show only devices with the specified vendor and product ID numbers (in hexadecimal) in format VID\:\[PID\]]:VIDPID:_default' \
 '-s+[Show only devices with specified device and/or bus numbers (in decimal) in format \[\[bus\]\:\]\[devnum\]]:SHOW:_default' \
 '--show=[Show only devices with specified device and/or bus numbers (in decimal) in format \[\[bus\]\:\]\[devnum\]]:SHOW:_default' \
 '-D+[Selects which device lsusb will examine - supplied as Linux /dev/bus/usb/BBB/DDD style path]:DEVICE:_default' \
@@ -48,6 +48,7 @@ wireless-controller\:"Wireless controllers\: Bluetooth adaptors, Microsoft RNDIS
 miscellaneous\:"This base class is defined for miscellaneous device definitions. Some matching SubClass and Protocols are defined on the USB-IF website"
 application-specific-interface\:"This base class is defined for devices that conform to several class specifications found on the USB-IF website"
 vendor-specific-class\:"This base class is defined for vendors to use as they please"))' \
+'*--exclude=[Exclude devices matching a KEY=VALUE predicate]:EXCLUDE:_default' \
 '*-b+[Specify the blocks which will be displayed for each device and in what order. Supply arg multiple times or csv to specify multiple blocks]:BLOCKS:((bus-number\:"Number of bus device is attached"
 device-number\:"Bus issued device number"
 branch-position\:"Position of device in parent branch"

--- a/doc/_cyme.ps1
+++ b/doc/_cyme.ps1
@@ -30,6 +30,7 @@ Register-ArgumentCompleter -Native -CommandName 'cyme' -ScriptBlock {
             [CompletionResult]::new('--filter-name', '--filter-name', [CompletionResultType]::ParameterName, 'Filter on string contained in name')
             [CompletionResult]::new('--filter-serial', '--filter-serial', [CompletionResultType]::ParameterName, 'Filter on string contained in serial')
             [CompletionResult]::new('--filter-class', '--filter-class', [CompletionResultType]::ParameterName, 'Filter on USB class code')
+            [CompletionResult]::new('--exclude', '--exclude', [CompletionResultType]::ParameterName, 'Exclude devices matching a KEY=VALUE predicate')
             [CompletionResult]::new('-b', '-b', [CompletionResultType]::ParameterName, 'Specify the blocks which will be displayed for each device and in what order. Supply arg multiple times or csv to specify multiple blocks')
             [CompletionResult]::new('--blocks', '--blocks', [CompletionResultType]::ParameterName, 'Specify the blocks which will be displayed for each device and in what order. Supply arg multiple times or csv to specify multiple blocks')
             [CompletionResult]::new('--bus-blocks', '--bus-blocks', [CompletionResultType]::ParameterName, 'Specify the blocks which will be displayed for each bus and in what order. Supply arg multiple times or csv to specify multiple blocks')

--- a/doc/cyme.1
+++ b/doc/cyme.1
@@ -4,7 +4,7 @@
 .SH NAME
 cyme \- List system USB buses and devices. A modern cross\-platform lsusb
 .SH SYNOPSIS
-\fBcyme\fR [\fB\-l\fR|\fB\-\-lsusb\fR] [\fB\-t\fR|\fB\-\-tree\fR] [\fB\-d\fR|\fB\-\-vidpid\fR] [\fB\-s\fR|\fB\-\-show\fR] [\fB\-D\fR|\fB\-\-device\fR] [\fB\-\-filter\-name\fR] [\fB\-\-filter\-serial\fR] [\fB\-\-filter\-class\fR] [\fB\-v\fR|\fB\-\-verbose\fR]... [\fB\-b\fR|\fB\-\-blocks\fR] [\fB\-\-bus\-blocks\fR] [\fB\-\-config\-blocks\fR] [\fB\-\-interface\-blocks\fR] [\fB\-\-endpoint\-blocks\fR] [\fB\-\-block\-operation\fR] [\fB\-m\fR|\fB\-\-more\fR] [\fB\-\-sort\-devices\fR] [\fB\-\-sort\-buses\fR] [\fB\-\-group\-devices\fR] [\fB\-\-hide\-buses\fR] [\fB\-\-hide\-hubs\fR] [\fB\-\-list\-root\-hubs\fR] [\fB\-\-decimal\fR] [\fB\-\-no\-padding\fR] [\fB\-\-color\fR] [\fB\-\-encoding\fR] [\fB\-\-icon\fR] [\fB\-\-headings\fR] [\fB\-\-json\fR] [\fB\-\-from\-json\fR] [\fB\-F\fR|\fB\-\-force\-libusb\fR] [\fB\-c\fR|\fB\-\-config\fR] [\fB\-z\fR|\fB\-\-debug\fR]... [\fB\-\-mask\-serials\fR] [\fB\-\-system\-profiler\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIsubcommands\fR]
+\fBcyme\fR [\fB\-l\fR|\fB\-\-lsusb\fR] [\fB\-t\fR|\fB\-\-tree\fR] [\fB\-d\fR|\fB\-\-vidpid\fR] [\fB\-s\fR|\fB\-\-show\fR] [\fB\-D\fR|\fB\-\-device\fR] [\fB\-\-filter\-name\fR] [\fB\-\-filter\-serial\fR] [\fB\-\-filter\-class\fR] [\fB\-\-exclude\fR] [\fB\-v\fR|\fB\-\-verbose\fR]... [\fB\-b\fR|\fB\-\-blocks\fR] [\fB\-\-bus\-blocks\fR] [\fB\-\-config\-blocks\fR] [\fB\-\-interface\-blocks\fR] [\fB\-\-endpoint\-blocks\fR] [\fB\-\-block\-operation\fR] [\fB\-m\fR|\fB\-\-more\fR] [\fB\-\-sort\-devices\fR] [\fB\-\-sort\-buses\fR] [\fB\-\-group\-devices\fR] [\fB\-\-hide\-buses\fR] [\fB\-\-hide\-hubs\fR] [\fB\-\-list\-root\-hubs\fR] [\fB\-\-decimal\fR] [\fB\-\-no\-padding\fR] [\fB\-\-color\fR] [\fB\-\-encoding\fR] [\fB\-\-icon\fR] [\fB\-\-headings\fR] [\fB\-\-json\fR] [\fB\-\-from\-json\fR] [\fB\-F\fR|\fB\-\-force\-libusb\fR] [\fB\-c\fR|\fB\-\-config\fR] [\fB\-z\fR|\fB\-\-debug\fR]... [\fB\-\-mask\-serials\fR] [\fB\-\-system\-profiler\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIsubcommands\fR]
 .SH DESCRIPTION
 List system USB buses and devices. A modern cross\-platform lsusb
 .SH OPTIONS
@@ -15,8 +15,10 @@ Attempt to maintain compatibility with lsusb output
 \fB\-t\fR, \fB\-\-tree\fR
 Dump USB device hierarchy as a tree
 .TP
-\fB\-d\fR, \fB\-\-vidpid\fR \fI<VIDPID>\fR
+\fB\-d\fR, \fB\-\-vidpid\fR \fI<VIDPID>...\fR
 Show only devices with the specified vendor and product ID numbers (in hexadecimal) in format VID:[PID]
+
+May be supplied multiple times and/or comma\-separated to match any of several devices, e.g. `\-\-vidpid 1d50:6018,0x05ac:`.
 .TP
 \fB\-s\fR, \fB\-\-show\fR \fI<SHOW>\fR
 Show only devices with specified device and/or bus numbers (in decimal) in format [[bus]:][devnum]
@@ -88,6 +90,15 @@ application\-specific\-interface: This base class is defined for devices that co
 .IP \(bu 2
 vendor\-specific\-class: This base class is defined for vendors to use as they please
 .RE
+.TP
+\fB\-\-exclude\fR \fI<EXCLUDE>...\fR
+Exclude devices matching a KEY=VALUE predicate.
+
+May be supplied multiple times and/or comma\-separated. Supported keys: `vidpid=VID:[PID]`, `name=STRING`, `serial=STRING`, `class=CLASS`. Exclude criteria are applied after include filters.
+
+Examples:
+
+\-\-exclude vidpid=1234:5678 \-\-exclude vidpid=1234:5678,name=Hub \-\-vidpid 0x05ac: \-\-exclude vidpid=05ac:8600
 .TP
 \fB\-v\fR, \fB\-\-verbose\fR
 Verbosity level (repeat provides count): 1 prints device configurations; 2 prints interfaces; 3 prints interface endpoints; 4 prints everything and more blocks

--- a/doc/cyme.bash
+++ b/doc/cyme.bash
@@ -35,7 +35,7 @@ _cyme() {
 
     case "${cmd}" in
         cyme)
-            opts="-l -t -d -s -D -v -b -m -F -c -z -h -V --lsusb --tree --vidpid --show --device --filter-name --filter-serial --filter-class --verbose --blocks --bus-blocks --config-blocks --interface-blocks --endpoint-blocks --block-operation --more --sort-devices --sort-buses --group-devices --hide-buses --hide-hubs --list-root-hubs --decimal --no-padding --color --no-color --encoding --ascii --no-icons --icon --headings --json --from-json --force-libusb --config --filter-post --debug --mask-serials --gen --system-profiler --help --version watch help"
+            opts="-l -t -d -s -D -v -b -m -F -c -z -h -V --lsusb --tree --vidpid --show --device --filter-name --filter-serial --filter-class --exclude --verbose --blocks --bus-blocks --config-blocks --interface-blocks --endpoint-blocks --block-operation --more --sort-devices --sort-buses --group-devices --hide-buses --hide-hubs --list-root-hubs --decimal --no-padding --color --no-color --encoding --ascii --no-icons --icon --headings --json --from-json --force-libusb --config --filter-post --debug --mask-serials --gen --system-profiler --help --version watch help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -75,6 +75,10 @@ _cyme() {
                     ;;
                 --filter-class)
                     COMPREPLY=($(compgen -W "use-interface-descriptor audio cdc-communications hid physical image printer mass-storage hub cdc-data smart-card content-security video personal-healthcare audio-video billboard usb-type-c-bridge bdp mctp i3c-device diagnostic wireless-controller miscellaneous application-specific-interface vendor-specific-class" -- "${cur}"))
+                    return 0
+                    ;;
+                --exclude)
+                    COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
                 --blocks)

--- a/doc/cyme.fish
+++ b/doc/cyme.fish
@@ -1,6 +1,6 @@
 # Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
 function __fish_cyme_global_optspecs
-	string join \n l/lsusb t/tree d/vidpid= s/show= D/device= filter-name= filter-serial= filter-class= v/verbose b/blocks= bus-blocks= config-blocks= interface-blocks= endpoint-blocks= block-operation= m/more sort-devices= sort-buses group-devices= hide-buses hide-hubs list-root-hubs decimal no-padding color= no-color encoding= ascii no-icons icon= headings json from-json= F/force-libusb c/config= filter-post z/debug mask-serials= gen system-profiler h/help V/version
+	string join \n l/lsusb t/tree d/vidpid= s/show= D/device= filter-name= filter-serial= filter-class= exclude= v/verbose b/blocks= bus-blocks= config-blocks= interface-blocks= endpoint-blocks= block-operation= m/more sort-devices= sort-buses group-devices= hide-buses hide-hubs list-root-hubs decimal no-padding color= no-color encoding= ascii no-icons icon= headings json from-json= F/force-libusb c/config= filter-post z/debug mask-serials= gen system-profiler h/help V/version
 end
 
 function __fish_cyme_needs_command
@@ -54,6 +54,7 @@ wireless-controller\t'Wireless controllers: Bluetooth adaptors, Microsoft RNDIS'
 miscellaneous\t'This base class is defined for miscellaneous device definitions. Some matching SubClass and Protocols are defined on the USB-IF website'
 application-specific-interface\t'This base class is defined for devices that conform to several class specifications found on the USB-IF website'
 vendor-specific-class\t'This base class is defined for vendors to use as they please'"
+complete -c cyme -n "__fish_cyme_needs_command" -l exclude -d 'Exclude devices matching a KEY=VALUE predicate' -r
 complete -c cyme -n "__fish_cyme_needs_command" -s b -l blocks -d 'Specify the blocks which will be displayed for each device and in what order. Supply arg multiple times or csv to specify multiple blocks' -r -f -a "bus-number\t'Number of bus device is attached'
 device-number\t'Bus issued device number'
 branch-position\t'Position of device in parent branch'

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 //! Where the magic happens for `cyme` binary!
 #[cfg(not(feature = "watch"))]
 use clap::Parser;
+use clap::ValueEnum;
 #[cfg(feature = "watch")]
 use clap::{Parser, Subcommand};
 use colored::*;
@@ -62,6 +63,20 @@ struct Args {
     /// Filter on USB class code
     #[arg(long)]
     filter_class: Option<BaseClass>,
+
+    /// Exclude devices matching a KEY=VALUE predicate.
+    ///
+    /// May be supplied multiple times and/or comma-separated. Supported
+    /// keys: `vidpid=VID:[PID]`, `name=STRING`, `serial=STRING`,
+    /// `class=CLASS`. Exclude criteria are applied after include filters.
+    ///
+    /// Examples:
+    ///
+    ///   --exclude vidpid=1234:5678
+    ///   --exclude vidpid=1234:5678,name=Hub
+    ///   --vidpid 0x05ac: --exclude vidpid=05ac:8600
+    #[arg(long, value_delimiter = ',', num_args = 1..)]
+    exclude: Vec<String>,
 
     /// Verbosity level (repeat provides count): 1 prints device configurations; 2 prints interfaces; 3 prints interface endpoints; 4 prints everything and more blocks
     #[arg(short = 'v', long, default_value_t = 0, action = clap::ArgAction::Count)]
@@ -314,6 +329,39 @@ fn merge_config(c: &mut Config, a: &Args) {
 fn parse_hex_u16(s: &str) -> Result<u16> {
     u16::from_str_radix(s.trim().trim_start_matches("0x"), 16)
         .map_err(|e| Error::new(ErrorKind::Parsing, &e.to_string()))
+}
+
+/// A single parsed entry from `--exclude KEY=VALUE`
+enum ExcludeEntry {
+    Vidpid((Option<u16>, Option<u16>)),
+    Name(String),
+    Serial(String),
+    Class(BaseClass),
+}
+
+/// Parse a single `--exclude` entry in `KEY=VALUE` form.
+fn parse_exclude(s: &str) -> Result<ExcludeEntry> {
+    let (key, value) = s.split_once('=').ok_or_else(|| {
+        Error::new(
+            ErrorKind::InvalidArg,
+            &format!("--exclude expects KEY=VALUE, got '{s}'"),
+        )
+    })?;
+    match key.trim() {
+        "vidpid" => Ok(ExcludeEntry::Vidpid(parse_vidpid(value)?)),
+        "name" => Ok(ExcludeEntry::Name(value.to_string())),
+        "serial" => Ok(ExcludeEntry::Serial(value.to_string())),
+        "class" => {
+            let class = BaseClass::from_str(value, true).map_err(|e| {
+                Error::new(ErrorKind::Parsing, &format!("Unknown class '{value}': {e}"))
+            })?;
+            Ok(ExcludeEntry::Class(class))
+        }
+        other => Err(Error::new(
+            ErrorKind::InvalidArg,
+            &format!("Unknown --exclude key '{other}'; supported: vidpid, name, serial, class"),
+        )),
+    }
 }
 
 /// Parse the vidpid filter lsusb format: vid:Option<pid>
@@ -760,6 +808,7 @@ fn cyme() -> Result<()> {
     let filter = if config.hide_hubs
         || config.hide_buses
         || !args.vidpid.is_empty()
+        || !args.exclude.is_empty()
         || args.show.is_some()
         || args.device.is_some()
         || args.filter_name.is_some()
@@ -776,6 +825,20 @@ fn cyme() -> Result<()> {
                 )
             })?;
             f.vidpid.push(pair);
+        }
+
+        for entry in &args.exclude {
+            match parse_exclude(entry.as_str()).map_err(|e| {
+                Error::new(
+                    ErrorKind::InvalidArg,
+                    &format!("Failed to parse --exclude '{entry}'; Error({e})"),
+                )
+            })? {
+                ExcludeEntry::Vidpid(pair) => f.exclude_vidpid.push(pair),
+                ExcludeEntry::Name(s) => f.exclude_name = Some(s),
+                ExcludeEntry::Serial(s) => f.exclude_serial = Some(s),
+                ExcludeEntry::Class(c) => f.exclude_class = Some(c),
+            }
         }
 
         // decode device devpath into the show filter since that is what it essentially will do
@@ -946,6 +1009,38 @@ mod tests {
         assert!(parse_hex_u16("0x10000").is_err());
         assert!(parse_hex_u16("0xdeadbeef").is_err());
         assert!(parse_hex_u16("zz").is_err());
+    }
+
+    #[test]
+    fn test_parse_exclude() {
+        match parse_exclude("vidpid=1234:5678").unwrap() {
+            ExcludeEntry::Vidpid((Some(0x1234), Some(0x5678))) => {}
+            _ => panic!("expected vidpid match"),
+        }
+        match parse_exclude("vidpid=0x1d50:").unwrap() {
+            ExcludeEntry::Vidpid((Some(0x1d50), None)) => {}
+            _ => panic!("expected vidpid vid-only match"),
+        }
+        match parse_exclude("name=Hub").unwrap() {
+            ExcludeEntry::Name(s) if s == "Hub" => {}
+            _ => panic!("expected name match"),
+        }
+        match parse_exclude("serial=abc123").unwrap() {
+            ExcludeEntry::Serial(s) if s == "abc123" => {}
+            _ => panic!("expected serial match"),
+        }
+        match parse_exclude("class=hub").unwrap() {
+            ExcludeEntry::Class(_) => {}
+            _ => panic!("expected class match"),
+        }
+        // missing '='
+        assert!(parse_exclude("vidpid1234:5678").is_err());
+        // unknown key
+        assert!(parse_exclude("foo=bar").is_err());
+        // invalid class
+        assert!(parse_exclude("class=not-a-class").is_err());
+        // overflow in vidpid
+        assert!(parse_exclude("vidpid=0x10000:0x1").is_err());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -304,36 +304,34 @@ fn merge_config(c: &mut Config, a: &Args) {
     c.verbose = c.verbose.max(a.verbose);
 }
 
+/// Parse a hexadecimal u16, accepting an optional `0x` prefix.
+///
+/// Unlike the previous implementation which parsed as `u32` and truncated via
+/// `as u16`, this rejects values that would overflow `u16` (e.g. `0x10000`).
+fn parse_hex_u16(s: &str) -> Result<u16> {
+    u16::from_str_radix(s.trim().trim_start_matches("0x"), 16)
+        .map_err(|e| Error::new(ErrorKind::Parsing, &e.to_string()))
+}
+
 /// Parse the vidpid filter lsusb format: vid:Option<pid>
 fn parse_vidpid(s: &str) -> Result<(Option<u16>, Option<u16>)> {
     let vid_split: Vec<&str> = s.split(':').collect();
     if vid_split.len() >= 2 {
-        let vid: Option<u16> =
-            vid_split
-                .first()
-                .filter(|v| !v.is_empty())
-                .map_or(Ok(None), |v| {
-                    u32::from_str_radix(v.trim().trim_start_matches("0x"), 16)
-                        .map(|v| Some(v as u16))
-                        .map_err(|e| Error::new(ErrorKind::Parsing, &e.to_string()))
-                })?;
-        let pid: Option<u16> =
-            vid_split
-                .get(1)
-                .filter(|v| !v.is_empty())
-                .map_or(Ok(None), |v| {
-                    u32::from_str_radix(v.trim().trim_start_matches("0x"), 16)
-                        .map(|v| Some(v as u16))
-                        .map_err(|e| Error::new(ErrorKind::Parsing, &e.to_string()))
-                })?;
+        let vid: Option<u16> = vid_split
+            .first()
+            .filter(|v| !v.is_empty())
+            .map(|v| parse_hex_u16(v))
+            .transpose()?;
+        let pid: Option<u16> = vid_split
+            .get(1)
+            .filter(|v| !v.is_empty())
+            .map(|v| parse_hex_u16(v))
+            .transpose()?;
 
         Ok((vid, pid))
     } else {
-        let vid: Option<u16> = u32::from_str_radix(s.trim().trim_start_matches("0x"), 16)
-            .map(|v| Some(v as u16))
-            .map_err(|e| Error::new(ErrorKind::Parsing, &e.to_string()))?;
-
-        Ok((vid, None))
+        let vid = parse_hex_u16(s)?;
+        Ok((Some(vid), None))
     }
 }
 
@@ -937,6 +935,18 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_hex_u16() {
+        assert_eq!(parse_hex_u16("0x1234").unwrap(), 0x1234);
+        assert_eq!(parse_hex_u16("1234").unwrap(), 0x1234);
+        assert_eq!(parse_hex_u16("FFFF").unwrap(), 0xFFFF);
+        assert_eq!(parse_hex_u16("0xffff").unwrap(), 0xFFFF);
+        // overflow: previously silently truncated via `u32 as u16`
+        assert!(parse_hex_u16("0x10000").is_err());
+        assert!(parse_hex_u16("0xdeadbeef").is_err());
+        assert!(parse_hex_u16("zz").is_err());
+    }
+
+    #[test]
     fn test_parse_vidpid() {
         assert_eq!(
             parse_vidpid("000A:0x000b").unwrap(),
@@ -946,6 +956,9 @@ mod tests {
         assert_eq!(parse_vidpid("000A:").unwrap(), (Some(0x0A), None));
         assert_eq!(parse_vidpid("0x000A").unwrap(), (Some(0x0A), None));
         assert!(parse_vidpid("dfg:sdfd").is_err());
+        // overflow on either side should error, not silently truncate
+        assert!(parse_vidpid("0x10000:0x1").is_err());
+        assert!(parse_vidpid("0x1:0x10000").is_err());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,8 +37,11 @@ struct Args {
     tree: bool,
 
     /// Show only devices with the specified vendor and product ID numbers (in hexadecimal) in format VID:[PID]
-    #[arg(short = 'd', long)]
-    vidpid: Option<String>,
+    ///
+    /// May be supplied multiple times and/or comma-separated to match any
+    /// of several devices, e.g. `--vidpid 1d50:6018,0x05ac:`.
+    #[arg(short = 'd', long, value_delimiter = ',', num_args = 1..)]
+    vidpid: Vec<String>,
 
     /// Show only devices with specified device and/or bus numbers (in decimal) in format [[bus]:][devnum]
     #[arg(short, long)]
@@ -756,7 +759,7 @@ fn cyme() -> Result<()> {
 
     let filter = if config.hide_hubs
         || config.hide_buses
-        || args.vidpid.is_some()
+        || !args.vidpid.is_empty()
         || args.show.is_some()
         || args.device.is_some()
         || args.filter_name.is_some()
@@ -765,15 +768,14 @@ fn cyme() -> Result<()> {
     {
         let mut f = profiler::Filter::new();
 
-        if let Some(vidpid) = &args.vidpid {
-            let (vid, pid) = parse_vidpid(vidpid.as_str()).map_err(|e| {
+        for vidpid in &args.vidpid {
+            let pair = parse_vidpid(vidpid.as_str()).map_err(|e| {
                 Error::new(
                     ErrorKind::InvalidArg,
                     &format!("Failed to parse vidpid '{vidpid}'; Error({e})"),
                 )
             })?;
-            f.vid = vid;
-            f.pid = pid;
+            f.vidpid.push(pair);
         }
 
         // decode device devpath into the show filter since that is what it essentially will do

--- a/src/profiler/types.rs
+++ b/src/profiler/types.rs
@@ -1988,10 +1988,13 @@ impl<'a> IntoIterator for &'a mut Device {
 /// The tree to a [`Device`] is kept even if parent branches are not matches. To avoid this, one must flatten the devices first.
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct Filter {
-    /// Retain only devices with vendor id matching this
-    pub vid: Option<u16>,
-    /// Retain only devices with product id matching this
-    pub pid: Option<u16>,
+    /// Retain only devices whose vendor/product id matches any entry in this list
+    ///
+    /// Each entry is a `(vid, pid)` pair where either side may be `None` to
+    /// match anything. An empty `Vec` disables the filter. Multiple entries
+    /// are combined with OR semantics (a device matches if any entry matches).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub vidpid: Vec<(Option<u16>, Option<u16>)>,
     /// Retain only devices on this bus
     pub bus: Option<u8>,
     /// Retain only devices with this device number
@@ -2115,8 +2118,7 @@ pub type USBFilter = Filter;
 ///
 /// # let mut spusb = read_json_dump(&"./tests/data/system_profiler_dump.json").unwrap();
 /// let filter = Filter {
-///     vid: Some(0x1d50),
-///     pid: Some(0x6018),
+///     vidpid: vec![(Some(0x1d50), Some(0x6018))],
 ///     ..Default::default()
 /// };
 /// filter.retain_buses(&mut spusb.buses);
@@ -2187,6 +2189,18 @@ impl Filter {
         }
     }
 
+    /// Checks whether any `vidpid` entry matches `device`. Empty `Vec` = no
+    /// filter and always returns true.
+    fn vidpid_matches(&self, device: &Device) -> bool {
+        if self.vidpid.is_empty() {
+            return true;
+        }
+        self.vidpid.iter().any(|(vid, pid)| {
+            vid.is_none_or(|v| device.vendor_id == Some(v))
+                && pid.is_none_or(|p| device.product_id == Some(p))
+        })
+    }
+
     /// Checks whether `device` passes through filter
     pub fn is_match(&self, device: &Device) -> bool {
         self.is_identity_match(device)
@@ -2198,8 +2212,7 @@ impl Filter {
     pub fn is_identity_match(&self, device: &Device) -> bool {
         (Some(device.location_id.bus) == self.bus || self.bus.is_none())
             && (Some(device.location_id.number) == self.number || self.number.is_none())
-            && (device.vendor_id == self.vid || self.vid.is_none())
-            && (device.product_id == self.pid || self.pid.is_none())
+            && self.vidpid_matches(device)
             && (self.string_match(&self.name, Some(&device.name)))
             && (self.string_match(&self.serial, device.serial_num.as_ref()))
             && self.class.as_ref().is_none_or(|fc| {
@@ -2213,8 +2226,7 @@ impl Filter {
     pub fn is_potential_match(&self, device: &Device) -> bool {
         (Some(device.location_id.bus) == self.bus || self.bus.is_none())
             && (Some(device.location_id.number) == self.number || self.number.is_none())
-            && (device.vendor_id == self.vid || self.vid.is_none())
-            && (device.product_id == self.pid || self.pid.is_none())
+            && self.vidpid_matches(device)
             && (self.string_match(&self.name, Some(&device.name)))
             && (self.string_match(&self.serial, device.serial_num.as_ref()))
             // if we have a class filter, it's a potential match if we haven't loaded extra data yet (to check interfaces)

--- a/src/profiler/types.rs
+++ b/src/profiler/types.rs
@@ -2005,6 +2005,21 @@ pub struct Filter {
     pub serial: Option<String>,
     /// retain only device of BaseClass class
     pub class: Option<BaseClass>,
+    /// Exclude devices whose vendor/product id matches any entry in this list
+    ///
+    /// Same shape and semantics as [`Filter::vidpid`] but inverted: a device
+    /// matching any entry is dropped. Empty `Vec` disables the exclusion.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub exclude_vidpid: Vec<(Option<u16>, Option<u16>)>,
+    /// Exclude devices whose name contains this string
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exclude_name: Option<String>,
+    /// Exclude devices whose serial contains this string
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exclude_serial: Option<String>,
+    /// Exclude devices of this BaseClass
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exclude_class: Option<BaseClass>,
     /// Exclude empty buses in the tree
     pub exclude_empty_bus: bool,
     /// Exclude empty hubs in the tree
@@ -2189,21 +2204,50 @@ impl Filter {
         }
     }
 
-    /// Checks whether any `vidpid` entry matches `device`. Empty `Vec` = no
-    /// filter and always returns true.
-    fn vidpid_matches(&self, device: &Device) -> bool {
-        if self.vidpid.is_empty() {
-            return true;
-        }
-        self.vidpid.iter().any(|(vid, pid)| {
+    /// Checks whether any entry in `vidpid_list` matches `device`.
+    fn any_vidpid_hit(list: &[(Option<u16>, Option<u16>)], device: &Device) -> bool {
+        list.iter().any(|(vid, pid)| {
             vid.is_none_or(|v| device.vendor_id == Some(v))
                 && pid.is_none_or(|p| device.product_id == Some(p))
         })
     }
 
+    /// Checks whether any `vidpid` entry matches `device`. Empty `Vec` = no
+    /// filter and always returns true.
+    fn vidpid_matches(&self, device: &Device) -> bool {
+        self.vidpid.is_empty() || Self::any_vidpid_hit(&self.vidpid, device)
+    }
+
+    /// Returns true if any exclude criterion matches `device`.
+    ///
+    /// An empty exclude set returns false (nothing is excluded). Multiple
+    /// exclude fields OR together — a device is excluded if *any* populated
+    /// criterion matches it.
+    pub fn is_excluded(&self, device: &Device) -> bool {
+        if !self.exclude_vidpid.is_empty() && Self::any_vidpid_hit(&self.exclude_vidpid, device) {
+            return true;
+        }
+        if self.exclude_name.is_some() && self.string_match(&self.exclude_name, Some(&device.name))
+        {
+            return true;
+        }
+        if self.exclude_serial.is_some()
+            && self.string_match(&self.exclude_serial, device.serial_num.as_ref())
+        {
+            return true;
+        }
+        if let Some(fc) = self.exclude_class.as_ref() {
+            if device.class.as_ref() == Some(fc) || device.has_interface_class(fc) {
+                return true;
+            }
+        }
+        false
+    }
+
     /// Checks whether `device` passes through filter
     pub fn is_match(&self, device: &Device) -> bool {
         self.is_identity_match(device)
+            && !self.is_excluded(device)
             && !(self.exclude_empty_hub && device.is_hub() && !device.has_devices())
             && (!device.is_root_hub() || self.no_exclude_root_hub)
     }
@@ -2222,9 +2266,16 @@ impl Filter {
 
     /// Checks whether `device` could potentially match filter if extra data was loaded
     ///
-    /// Used by profilers to decide whether to load extra data for a device
+    /// Used by profilers to decide whether to load extra data for a device.
+    /// Include criteria use the usual is_none_or-style checks. Exclude
+    /// criteria prune only when the decision can be made with the pre-probe
+    /// data already in hand: vidpid is always known, but class and
+    /// interface-derived checks need extras to be authoritative, so when
+    /// `device.extra` is not yet loaded we keep the device as a potential
+    /// match and let the final `is_match` pass decide.
     pub fn is_potential_match(&self, device: &Device) -> bool {
-        (Some(device.location_id.bus) == self.bus || self.bus.is_none())
+        // include side
+        let include_ok = (Some(device.location_id.bus) == self.bus || self.bus.is_none())
             && (Some(device.location_id.number) == self.number || self.number.is_none())
             && self.vidpid_matches(device)
             && (self.string_match(&self.name, Some(&device.name)))
@@ -2233,7 +2284,35 @@ impl Filter {
             && self.class.as_ref().is_none_or(|fc| {
                 device.class.as_ref() == Some(fc) || device.extra.is_none()
             })
-            && (!device.is_root_hub() || self.no_exclude_root_hub)
+            && (!device.is_root_hub() || self.no_exclude_root_hub);
+
+        if !include_ok {
+            return false;
+        }
+
+        // exclude side — only prune on criteria we can decide pre-extras
+        if !self.exclude_vidpid.is_empty() && Self::any_vidpid_hit(&self.exclude_vidpid, device) {
+            return false;
+        }
+        if self.exclude_name.is_some() && self.string_match(&self.exclude_name, Some(&device.name))
+        {
+            return false;
+        }
+        if self.exclude_serial.is_some()
+            && self.string_match(&self.exclude_serial, device.serial_num.as_ref())
+        {
+            return false;
+        }
+        // base class is always known; interface class needs extras to be authoritative
+        let class_excluded = self.exclude_class.as_ref().is_some_and(|fc| {
+            device.class.as_ref() == Some(fc)
+                || (device.extra.is_some() && device.has_interface_class(fc))
+        });
+        if class_excluded {
+            return false;
+        }
+
+        true
     }
 
     /// Checks whether `bus` passes through filter
@@ -2560,5 +2639,98 @@ mod tests {
     #[test]
     fn test_json_dump_read_not_panic() {
         read_json_dump("./tests/data/system_profiler_dump.json").unwrap();
+    }
+
+    /// Build a minimal synthetic `Device` for filter unit testing.
+    fn mk_device(vid: u16, pid: u16, name: &str) -> Device {
+        Device {
+            name: name.to_string(),
+            vendor_id: Some(vid),
+            product_id: Some(pid),
+            location_id: DeviceLocation {
+                bus: 1,
+                tree_positions: vec![1],
+                number: 2,
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_filter_vidpid_multi_or() {
+        let d1 = mk_device(0x1d50, 0x6018, "Black Magic Probe");
+        let d2 = mk_device(0x05ac, 0x8600, "Apple Internal Keyboard");
+        let d3 = mk_device(0x0bda, 0x0129, "Realtek SD Reader");
+
+        let filter = Filter {
+            vidpid: vec![(Some(0x1d50), Some(0x6018)), (Some(0x05ac), None)],
+            ..Default::default()
+        };
+
+        assert!(filter.is_match(&d1));
+        assert!(filter.is_match(&d2));
+        assert!(!filter.is_match(&d3));
+        // potential match agrees on the pre-probe fields
+        assert!(filter.is_potential_match(&d1));
+        assert!(filter.is_potential_match(&d2));
+        assert!(!filter.is_potential_match(&d3));
+    }
+
+    #[test]
+    fn test_filter_exclude_vidpid() {
+        let d1 = mk_device(0x1d50, 0x6018, "Black Magic Probe");
+        let d2 = mk_device(0x05ac, 0x8600, "Apple Internal Keyboard");
+
+        let filter = Filter {
+            exclude_vidpid: vec![(Some(0x1d50), Some(0x6018))],
+            ..Default::default()
+        };
+
+        assert!(!filter.is_match(&d1));
+        assert!(filter.is_match(&d2));
+        // profiler pruning: exclude is precise for vidpid
+        assert!(!filter.is_potential_match(&d1));
+        assert!(filter.is_potential_match(&d2));
+    }
+
+    #[test]
+    fn test_filter_include_plus_exclude_composition() {
+        let d_bmp = mk_device(0x05ac, 0x1234, "Magic Keyboard");
+        let d_specific = mk_device(0x05ac, 0x8600, "Apple Internal Keyboard");
+        let d_other = mk_device(0x0bda, 0x0129, "Realtek SD Reader");
+
+        // include all Apple devices but exclude one specific product
+        let filter = Filter {
+            vidpid: vec![(Some(0x05ac), None)],
+            exclude_vidpid: vec![(Some(0x05ac), Some(0x8600))],
+            ..Default::default()
+        };
+
+        assert!(filter.is_match(&d_bmp));
+        assert!(!filter.is_match(&d_specific));
+        assert!(!filter.is_match(&d_other));
+    }
+
+    #[test]
+    fn test_filter_exclude_name() {
+        let d1 = mk_device(0x1d50, 0x6018, "Black Magic Probe");
+        let d2 = mk_device(0x05ac, 0x8600, "Apple Internal Keyboard");
+
+        let filter = Filter {
+            exclude_name: Some("Magic".to_string()),
+            ..Default::default()
+        };
+
+        // "Magic" appears in d1 but not d2
+        assert!(!filter.is_match(&d1));
+        assert!(filter.is_match(&d2));
+    }
+
+    #[test]
+    fn test_filter_empty_exclude_is_noop() {
+        let d = mk_device(0x1d50, 0x6018, "Black Magic Probe");
+        let filter = Filter::default();
+        assert!(filter.is_match(&d));
+        assert!(!filter.is_excluded(&d));
     }
 }

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -162,13 +162,11 @@ fn set_filter(field: &FilterField, value: Option<String>, filter: &mut Filter) -
         FilterField::Serial => filter.serial = value,
         FilterField::VidPid => match value {
             Some(s) => {
-                let (vid, pid) = parse_vidpid(&s)?;
-                filter.vid = vid;
-                filter.pid = pid;
+                let pair = parse_vidpid(&s)?;
+                filter.vidpid = vec![pair];
             }
             None => {
-                filter.vid = None;
-                filter.pid = None;
+                filter.vidpid.clear();
             }
         },
         FilterField::Class => match value {
@@ -460,9 +458,10 @@ pub fn watch_usb_devices(
                 let original = match field {
                     FilterField::Name => display.filter.name.clone(),
                     FilterField::Serial => display.filter.serial.clone(),
-                    FilterField::VidPid => match (display.filter.vid, display.filter.pid) {
-                        (Some(vid), Some(pid)) => Some(format!("{vid:04x}:{pid:04x}")),
-                        (Some(vid), None) => Some(format!("{vid:04x}")),
+                    FilterField::VidPid => match display.filter.vidpid.first() {
+                        Some((Some(vid), Some(pid))) => Some(format!("{vid:04x}:{pid:04x}")),
+                        Some((Some(vid), None)) => Some(format!("{vid:04x}")),
+                        Some((None, Some(pid))) => Some(format!(":{pid:04x}")),
                         _ => None,
                     },
                     FilterField::Class => display.filter.class.map(|c| c.to_string()),
@@ -1139,17 +1138,25 @@ impl Display {
                 )
             }
             _ => {
+                let vidpid_display = if self.filter.vidpid.is_empty() {
+                    ":".to_string()
+                } else {
+                    self.filter
+                        .vidpid
+                        .iter()
+                        .map(|(vid, pid)| {
+                            format!(
+                                "{}:{}",
+                                vid.map_or(String::new(), |v| format!("{v:04x}")),
+                                pid.map_or(String::new(), |p| format!("{p:04x}")),
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                        .join(",")
+                };
                 format!(
-                    " FILTERS Name={:?} Serial={:?} VID:PID={}:{} Class={:?}",
-                    self.filter.name,
-                    self.filter.serial,
-                    self.filter
-                        .vid
-                        .map_or("".to_string(), |v| format!("{v:04x}")),
-                    self.filter
-                        .pid
-                        .map_or("".to_string(), |p| format!("{p:04x}")),
-                    self.filter.class
+                    " FILTERS Name={:?} Serial={:?} VID:PID={} Class={:?}",
+                    self.filter.name, self.filter.serial, vidpid_display, self.filter.class
                 )
             }
         };

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -162,6 +162,98 @@ fn test_tree_filtering() {
 }
 
 #[test]
+fn test_vidpid_multi_value() {
+    let env = common::TestEnv::new();
+
+    // repeated --vidpid and comma-separated should both accumulate into the
+    // same Filter.vidpid Vec, so their outputs must be identical.
+    let out_repeated = env.assert_success_and_get_output(
+        Some(common::CYME_LIBUSB_LINUX_TREE_DUMP),
+        &["--json", "--vidpid", "1d50:6018", "--vidpid", "05ac:"],
+    );
+    let out_csv = env.assert_success_and_get_output(
+        Some(common::CYME_LIBUSB_LINUX_TREE_DUMP),
+        &["--json", "--vidpid", "1d50:6018,05ac:"],
+    );
+    assert_eq!(out_repeated, out_csv);
+}
+
+#[test]
+fn test_exclude_vidpid() {
+    let env = common::TestEnv::new();
+
+    let mut comp_sp = common::sp_data_from_libusb_linux();
+    let filter = cyme::profiler::Filter {
+        exclude_vidpid: vec![(Some(0x1d50), Some(0x6018))],
+        no_exclude_root_hub: true,
+        ..Default::default()
+    };
+    comp_sp.into_flattened();
+    let mut devices = comp_sp.flattened_devices();
+    filter.retain_flattened_devices_ref(&mut devices);
+    let comp = serde_json::to_string_pretty(&devices).unwrap();
+
+    env.assert_output(
+        Some(common::CYME_LIBUSB_LINUX_TREE_DUMP),
+        &["--json", "--exclude", "vidpid=1d50:6018"],
+        &comp,
+        false,
+    );
+}
+
+#[test]
+fn test_exclude_include_composition() {
+    let env = common::TestEnv::new();
+
+    // include all 1d50 devices but exclude the specific 1d50:6018 pair
+    let mut comp_sp = common::sp_data_from_libusb_linux();
+    let filter = cyme::profiler::Filter {
+        vidpid: vec![(Some(0x1d50), None)],
+        exclude_vidpid: vec![(Some(0x1d50), Some(0x6018))],
+        no_exclude_root_hub: true,
+        ..Default::default()
+    };
+    comp_sp.into_flattened();
+    let mut devices = comp_sp.flattened_devices();
+    filter.retain_flattened_devices_ref(&mut devices);
+    let comp = serde_json::to_string_pretty(&devices).unwrap();
+
+    env.assert_output(
+        Some(common::CYME_LIBUSB_LINUX_TREE_DUMP),
+        &[
+            "--json",
+            "--vidpid",
+            "1d50",
+            "--exclude",
+            "vidpid=1d50:6018",
+        ],
+        &comp,
+        false,
+    );
+}
+
+#[test]
+fn test_exclude_parse_errors() {
+    let env = common::TestEnv::new();
+
+    // missing '='
+    env.assert_failure(
+        Some(common::CYME_LIBUSB_LINUX_TREE_DUMP),
+        &["--json", "--exclude", "vidpid1d50:6018"],
+    );
+    // unknown key
+    env.assert_failure(
+        Some(common::CYME_LIBUSB_LINUX_TREE_DUMP),
+        &["--json", "--exclude", "foo=bar"],
+    );
+    // u16 overflow in exclude vidpid
+    env.assert_failure(
+        Some(common::CYME_LIBUSB_LINUX_TREE_DUMP),
+        &["--json", "--exclude", "vidpid=0x10000:0x1"],
+    );
+}
+
+#[test]
 fn test_device_filter() {
     let env = common::TestEnv::new();
 


### PR DESCRIPTION
## Summary

Replaces the original `--exclude-vidpid` approach with a composable `--exclude KEY=VALUE` flag, and upgrades `--vidpid` to multi-value. See the comment below for the full rationale.

- `--vidpid`/`-d` now accepts multiple values (repeat the flag or comma-separated), e.g. `cyme -d 1d50:6018 -d 0x05ac:` or `cyme -d 1d50:6018,0x05ac:`.
- `--exclude KEY=VALUE` excludes devices. Keys: `vidpid`, `name`, `serial`, `class`. Repeatable and comma-separated. Composes with include filters.
- `Filter` grows parallel `exclude_vidpid`, `exclude_name`, `exclude_serial`, `exclude_class` fields plus an `is_excluded` helper. Matching is explicit: `include_hits(d) && !exclude_hits(d)`.
- `is_potential_match` is updated to prune excluded devices pre-probe when the decision is authoritative (vidpid, name, serial, base class), so profilers don't waste time loading extras for devices that will be dropped.

### Example

```sh
# match multiple devices
cyme --vidpid 1d50:6018,0x05ac:

# exclude a specific device
cyme --exclude vidpid=1234:5678

# all Apple devices *except* one specific product
cyme --vidpid 0x05ac: --exclude vidpid=05ac:8600

# combine multiple exclude keys
cyme --exclude vidpid=1234:5678,name=Hub
```

### Breaking change (library)

`Filter::vid: Option<u16>` and `Filter::pid: Option<u16>` are replaced by a single `vidpid: Vec<(Option<u16>, Option<u16>)>`. Migration:

```rust
// before
Filter { vid: Some(0x1d50), pid: Some(0x6018), ..Default::default() }
// after
Filter { vidpid: vec![(Some(0x1d50), Some(0x6018))], ..Default::default() }
```

### Also fixes

- `parse_vidpid` used `u32::from_str_radix(...) as u16` and silently wrapped on overflow (e.g. `0x10000:0x1` → `(0x0, 0x1)`). Now parsed as `u16` directly via a shared `parse_hex_u16` helper; overflow returns a parse error.

Addresses all three Copilot review comments from the initial revision (u16 truncation, `is_potential_match` consistency, integration test coverage).

## Commits

1. `fix(cli): parse vidpid as u16 without silent truncation` — bug fix + tests.
2. `refactor(filter)!: Filter.vid/pid -> vidpid: Vec<_>` — Filter API change + `--vidpid` multi-value.
3. `feat(cli): add --exclude KEY=VALUE to exclude devices` — new flag + parallel Filter fields + potential-match pruning + unit tests.
4. `test: integration coverage for multi --vidpid and --exclude` — integration tests, README, CHANGELOG, regenerated man page & shell completions.

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --bin cyme --test integration_test --doc`
- [ ] Manual test on host hardware: `cyme --vidpid a:b,c:d`, `cyme --exclude vidpid=a:b`, include+exclude composition