### PR TITLE
Support multi-arg filtering and exclude filters

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,120 @@
+name: Benchmark comparison
+
+on:
+  workflow_dispatch:
+    inputs:
+      compare_ref:
+        description: 'Branch/ref to compare against (baseline)'
+        required: false
+        default: 'main'
+      hyperfine_args:
+        description: 'Arguments passed to both cyme binaries for hyperfine (e.g. "--lsusb")'
+        required: false
+        default: ''
+
+jobs:
+  bench-baseline:
+    name: Benchmark ${{ inputs.compare_ref || 'main' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ inputs.compare_ref || 'main' }}
+
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ubuntu-latest-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install prerequisites
+        run: sudo apt-get -y update && sudo apt-get -y install libudev-dev libusb-1.0-0-dev
+
+      - name: Run cargo bench (save baseline)
+        run: cargo bench -- --save-baseline base 2>&1 | tee bench-baseline.txt
+
+      - name: Upload criterion baseline
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: criterion-baseline
+          path: target/criterion
+
+      - name: Build release binary
+        run: cargo build --release
+
+      - name: Upload baseline binary
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: cyme-baseline
+          path: target/release/cyme
+
+  bench-feature:
+    name: Benchmark ${{ github.ref_name }}
+    runs-on: ubuntu-latest
+    needs: bench-baseline
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ubuntu-latest-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install prerequisites
+        run: sudo apt-get -y update && sudo apt-get -y install libudev-dev libusb-1.0-0-dev hyperfine
+
+      - name: Download criterion baseline
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: criterion-baseline
+          path: target/criterion
+
+      - name: Run cargo bench (compare against baseline)
+        run: cargo bench -- --baseline base 2>&1 | tee bench-feature.txt
+
+      - name: Build release binary
+        run: cargo build --release
+
+      - name: Download baseline binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: cyme-baseline
+          path: cyme-baseline
+
+      - name: Make baseline binary executable
+        run: chmod +x cyme-baseline/cyme
+
+      - name: Run hyperfine comparison
+        run: |
+          hyperfine \
+            --warmup 3 \
+            --export-markdown hyperfine-results.md \
+            --command-name "${{ inputs.compare_ref || 'main' }}" "cyme-baseline/cyme ${{ inputs.hyperfine_args }}" \
+            --command-name "${{ github.ref_name }}" "target/release/cyme ${{ inputs.hyperfine_args }}"
+
+      - name: Write job summary
+        if: always()
+        run: |
+          echo "## cargo bench: \`${{ github.ref_name }}\` vs \`${{ inputs.compare_ref || 'main' }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat bench-feature.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## hyperfine: \`${{ github.ref_name }}\` vs \`${{ inputs.compare_ref || 'main' }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          cat hyperfine-results.md >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: bench-results
+          path: |
+            bench-feature.txt
+            hyperfine-results.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- filter: multi-value `--filter-*` CLI args (same arg OR'd, different args AND'd via cross-product), `--filter-exclude KEY=VALUE` for excluding devices, and `filter-include`/`filter-exclude` config keys ([#111](https://github.com/tuna-f1sh/cyme/pull/111)).
+
+### Changed
+
+- filter: **breaking crate API** — `Filter` is now a single-criterion struct within the new `DeviceFilter` container type, which replaces `Option<Filter>` in `ProfilerOptions` and owns the `retain_*`/`hide_*` methods; use `DeviceFilter::from(filter)` to migrate ([#111](https://github.com/tuna-f1sh/cyme/pull/111)).
+
+### Fixed
+
+- profiler: windows: fix manufacturer string always none on windows falling back to usb.ids ([#110](https://github.com/tuna-f1sh/cyme/issues/110)).
+
 ## [2.3.0] - 2025-03-29
 
 Big reduction of profiling time^ when filtering by passing options with filter to profiler. Previously, filtering was done post profiling of all devices - even those that would be filtered out. This included opening descriptors and reading data for redundant devices.

--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ cyme --filter-class hid --filter-exclude name=Keyboard
 cyme --filter-exclude vidpid=05ac:8600,name=Hub
 ```
 
+Filtering can also be configured in the config file. See './doc/cyme_example_filter_config.json' as an example - demo showing all fields, not designed to be used verbatum!
+
 ### JSON - jq
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The name comes from the technical term for the type of blossom on a Apple tree: 
 
 * Compatible with `lsusb` using `--lsusb` argument. Supports all arguments including `--verbose` output - fully parsed device descriptors! Output is identical for use with no args (list), tree (excluding drivers on non-Linux) and should match for verbose (perhaps formatting differences).
 * Default build is a native Rust profiler using [nusb](https://docs.rs/nusb/latest/nusb).
-* Filters like `lsusb` but that also work when printing `--tree`. Adds `--filter-name`, `--filter-serial`, `--filter-class` and option to hide empty `--hide-buses`/`--hide-hubs`.
+* Filters like `lsusb` but that also work when printing `--tree`. Adds `--filter-name`, `--filter-serial`, `--filter-class` and option to hide empty `--hide-buses`/`--hide-hubs`. Also invert with `--filter-exclude`.
 * Improved `--tree` mode; shows device, configurations, interfaces and endpoints as tree depending on level of `--verbose`.
 * Controllable display `--blocks` for device, bus `--bus-blocks`, configurations `--config-blocks`, interfaces `--interface-blocks` and endpoints `--endpoint-blocks`. Use `--more` to see more by default.
 * Modern terminal features with coloured output, utf-8 characters and icon look-up based device data. Can be turned off and customised. See `--encoding` (glyphs [default], utf8 and ascii), which can keep icons/tree within a certain encoding, `--color` (auto [default], always and never) and `--icon` (auto [default], always and never). Auto `--icon` will only show icons if all icons to be shown are supported by the `--encoding`.
@@ -173,8 +173,18 @@ cyme --block-operation remove --blocks serial
 cyme -d 0x05ac
 # Specifically an Apple Headset, masking the serial number with '*'
 cyme -d 05ac:8103 --mask-serials hide
-# Filter for only devices with a certain name and class (filters can be combined)
+# Filter for only devices with a certain name and class (different flags AND together)
 cyme --filter-name "Black Magic" --filter-class cdc-data
+# OR two vendors by repeating the flag (each occurrence is a separate OR'd filter)
+cyme -d 0x05ac -d 0x1d50
+# OR two names
+cyme --filter-name "Black Magic" --filter-name "FTDI"
+# Exclude specific devices with --filter-exclude (KEY=VALUE, keys: vidpid, name, serial, class, bus, number)
+cyme --filter-exclude vidpid=05ac:8600
+# Exclude all keyboards while still filtering by class
+cyme --filter-class hid --filter-exclude name=Keyboard
+# Comma-separate pairs to AND within one exclusion; repeat the flag to OR exclusions
+cyme --filter-exclude vidpid=05ac:8600,name=Hub
 ```
 
 ### JSON - jq

--- a/doc/_cyme
+++ b/doc/_cyme
@@ -15,15 +15,15 @@ _cyme() {
 
     local context curcontext="$curcontext" state line
     _arguments "${_arguments_options[@]}" : \
-'-d+[Show only devices with the specified vendor and product ID numbers (in hexadecimal) in format VID\:\[PID\]]:VIDPID:_default' \
-'--vidpid=[Show only devices with the specified vendor and product ID numbers (in hexadecimal) in format VID\:\[PID\]]:VIDPID:_default' \
+'*-d+[Show only devices with the specified vendor and product ID numbers (in hexadecimal) in format VID\:\[PID\]]:VID:[PID]:_default' \
+'*--vidpid=[Show only devices with the specified vendor and product ID numbers (in hexadecimal) in format VID\:\[PID\]]:VID:[PID]:_default' \
 '-s+[Show only devices with specified device and/or bus numbers (in decimal) in format \[\[bus\]\:\]\[devnum\]]:SHOW:_default' \
 '--show=[Show only devices with specified device and/or bus numbers (in decimal) in format \[\[bus\]\:\]\[devnum\]]:SHOW:_default' \
 '-D+[Selects which device lsusb will examine - supplied as Linux /dev/bus/usb/BBB/DDD style path]:DEVICE:_default' \
 '--device=[Selects which device lsusb will examine - supplied as Linux /dev/bus/usb/BBB/DDD style path]:DEVICE:_default' \
-'--filter-name=[Filter on string contained in name]:FILTER_NAME:_default' \
-'--filter-serial=[Filter on string contained in serial]:FILTER_SERIAL:_default' \
-'--filter-class=[Filter on USB class code]:FILTER_CLASS:((use-interface-descriptor\:"Device class is unspecified, interface descriptors are used to determine needed drivers"
+'*--filter-name=[Filter on string contained in name]:FILTER_NAME:_default' \
+'*--filter-serial=[Filter on string contained in serial]:FILTER_SERIAL:_default' \
+'*--filter-class=[Filter on USB class code]:FILTER_CLASS:((use-interface-descriptor\:"Device class is unspecified, interface descriptors are used to determine needed drivers"
 audio\:"Speaker, microphone, sound card, MIDI"
 cdc-communications\:"The modern serial interface; appears as a UART/RS232 port on most systems"
 hid\:"Human Interface Device; game controllers, keyboards, mice etc. Also commonly used as a device data interface rather then creating something from scratch"
@@ -48,6 +48,7 @@ wireless-controller\:"Wireless controllers\: Bluetooth adaptors, Microsoft RNDIS
 miscellaneous\:"This base class is defined for miscellaneous device definitions. Some matching SubClass and Protocols are defined on the USB-IF website"
 application-specific-interface\:"This base class is defined for devices that conform to several class specifications found on the USB-IF website"
 vendor-specific-class\:"This base class is defined for vendors to use as they please"))' \
+'*--filter-exclude=[Exclude devices matching KEY=VALUE criteria. KEY is one of\: vidpid, name, serial, class, bus, number. Comma-separate multiple KEY=VALUE pairs to AND them (one occurrence). Repeat the arg to OR exclusions]:KEY=VALUE:_default' \
 '*-b+[Specify the blocks which will be displayed for each device and in what order. Supply arg multiple times or csv to specify multiple blocks]:BLOCKS:((bus-number\:"Number of bus device is attached"
 device-number\:"Bus issued device number"
 branch-position\:"Position of device in parent branch"

--- a/doc/_cyme.ps1
+++ b/doc/_cyme.ps1
@@ -30,6 +30,7 @@ Register-ArgumentCompleter -Native -CommandName 'cyme' -ScriptBlock {
             [CompletionResult]::new('--filter-name', '--filter-name', [CompletionResultType]::ParameterName, 'Filter on string contained in name')
             [CompletionResult]::new('--filter-serial', '--filter-serial', [CompletionResultType]::ParameterName, 'Filter on string contained in serial')
             [CompletionResult]::new('--filter-class', '--filter-class', [CompletionResultType]::ParameterName, 'Filter on USB class code')
+            [CompletionResult]::new('--filter-exclude', '--filter-exclude', [CompletionResultType]::ParameterName, 'Exclude devices matching KEY=VALUE criteria. KEY is one of: vidpid, name, serial, class, bus, number. Comma-separate multiple KEY=VALUE pairs to AND them (one occurrence). Repeat the arg to OR exclusions')
             [CompletionResult]::new('-b', '-b', [CompletionResultType]::ParameterName, 'Specify the blocks which will be displayed for each device and in what order. Supply arg multiple times or csv to specify multiple blocks')
             [CompletionResult]::new('--blocks', '--blocks', [CompletionResultType]::ParameterName, 'Specify the blocks which will be displayed for each device and in what order. Supply arg multiple times or csv to specify multiple blocks')
             [CompletionResult]::new('--bus-blocks', '--bus-blocks', [CompletionResultType]::ParameterName, 'Specify the blocks which will be displayed for each bus and in what order. Supply arg multiple times or csv to specify multiple blocks')

--- a/doc/cyme.1
+++ b/doc/cyme.1
@@ -4,7 +4,7 @@
 .SH NAME
 cyme \- List system USB buses and devices. A modern cross\-platform lsusb
 .SH SYNOPSIS
-\fBcyme\fR [\fB\-l\fR|\fB\-\-lsusb\fR] [\fB\-t\fR|\fB\-\-tree\fR] [\fB\-d\fR|\fB\-\-vidpid\fR] [\fB\-s\fR|\fB\-\-show\fR] [\fB\-D\fR|\fB\-\-device\fR] [\fB\-\-filter\-name\fR] [\fB\-\-filter\-serial\fR] [\fB\-\-filter\-class\fR] [\fB\-v\fR|\fB\-\-verbose\fR]... [\fB\-b\fR|\fB\-\-blocks\fR] [\fB\-\-bus\-blocks\fR] [\fB\-\-config\-blocks\fR] [\fB\-\-interface\-blocks\fR] [\fB\-\-endpoint\-blocks\fR] [\fB\-\-block\-operation\fR] [\fB\-m\fR|\fB\-\-more\fR] [\fB\-\-sort\-devices\fR] [\fB\-\-sort\-buses\fR] [\fB\-\-group\-devices\fR] [\fB\-\-hide\-buses\fR] [\fB\-\-hide\-hubs\fR] [\fB\-\-list\-root\-hubs\fR] [\fB\-\-decimal\fR] [\fB\-\-no\-padding\fR] [\fB\-\-color\fR] [\fB\-\-encoding\fR] [\fB\-\-icon\fR] [\fB\-\-headings\fR] [\fB\-\-json\fR] [\fB\-\-from\-json\fR] [\fB\-F\fR|\fB\-\-force\-libusb\fR] [\fB\-c\fR|\fB\-\-config\fR] [\fB\-z\fR|\fB\-\-debug\fR]... [\fB\-\-mask\-serials\fR] [\fB\-\-system\-profiler\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIsubcommands\fR]
+\fBcyme\fR [\fB\-l\fR|\fB\-\-lsusb\fR] [\fB\-t\fR|\fB\-\-tree\fR] [\fB\-d\fR|\fB\-\-vidpid\fR] [\fB\-s\fR|\fB\-\-show\fR] [\fB\-D\fR|\fB\-\-device\fR] [\fB\-\-filter\-name\fR] [\fB\-\-filter\-serial\fR] [\fB\-\-filter\-class\fR] [\fB\-\-filter\-exclude\fR] [\fB\-v\fR|\fB\-\-verbose\fR]... [\fB\-b\fR|\fB\-\-blocks\fR] [\fB\-\-bus\-blocks\fR] [\fB\-\-config\-blocks\fR] [\fB\-\-interface\-blocks\fR] [\fB\-\-endpoint\-blocks\fR] [\fB\-\-block\-operation\fR] [\fB\-m\fR|\fB\-\-more\fR] [\fB\-\-sort\-devices\fR] [\fB\-\-sort\-buses\fR] [\fB\-\-group\-devices\fR] [\fB\-\-hide\-buses\fR] [\fB\-\-hide\-hubs\fR] [\fB\-\-list\-root\-hubs\fR] [\fB\-\-decimal\fR] [\fB\-\-no\-padding\fR] [\fB\-\-color\fR] [\fB\-\-encoding\fR] [\fB\-\-icon\fR] [\fB\-\-headings\fR] [\fB\-\-json\fR] [\fB\-\-from\-json\fR] [\fB\-F\fR|\fB\-\-force\-libusb\fR] [\fB\-c\fR|\fB\-\-config\fR] [\fB\-z\fR|\fB\-\-debug\fR]... [\fB\-\-mask\-serials\fR] [\fB\-\-system\-profiler\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIsubcommands\fR]
 .SH DESCRIPTION
 List system USB buses and devices. A modern cross\-platform lsusb
 .SH OPTIONS
@@ -15,7 +15,7 @@ Attempt to maintain compatibility with lsusb output
 \fB\-t\fR, \fB\-\-tree\fR
 Dump USB device hierarchy as a tree
 .TP
-\fB\-d\fR, \fB\-\-vidpid\fR \fI<VIDPID>\fR
+\fB\-d\fR, \fB\-\-vidpid\fR \fI<VID:[PID]>\fR
 Show only devices with the specified vendor and product ID numbers (in hexadecimal) in format VID:[PID]
 .TP
 \fB\-s\fR, \fB\-\-show\fR \fI<SHOW>\fR
@@ -88,6 +88,9 @@ application\-specific\-interface: This base class is defined for devices that co
 .IP \(bu 2
 vendor\-specific\-class: This base class is defined for vendors to use as they please
 .RE
+.TP
+\fB\-\-filter\-exclude\fR \fI<KEY=VALUE>\fR
+Exclude devices matching KEY=VALUE criteria. KEY is one of: vidpid, name, serial, class, bus, number. Comma\-separate multiple KEY=VALUE pairs to AND them (one occurrence). Repeat the arg to OR exclusions
 .TP
 \fB\-v\fR, \fB\-\-verbose\fR
 Verbosity level (repeat provides count): 1 prints device configurations; 2 prints interfaces; 3 prints interface endpoints; 4 prints everything and more blocks

--- a/doc/cyme.bash
+++ b/doc/cyme.bash
@@ -35,7 +35,7 @@ _cyme() {
 
     case "${cmd}" in
         cyme)
-            opts="-l -t -d -s -D -v -b -m -F -c -z -h -V --lsusb --tree --vidpid --show --device --filter-name --filter-serial --filter-class --verbose --blocks --bus-blocks --config-blocks --interface-blocks --endpoint-blocks --block-operation --more --sort-devices --sort-buses --group-devices --hide-buses --hide-hubs --list-root-hubs --decimal --no-padding --color --no-color --encoding --ascii --no-icons --icon --headings --json --from-json --force-libusb --config --filter-post --debug --mask-serials --gen --system-profiler --help --version watch help"
+            opts="-l -t -d -s -D -v -b -m -F -c -z -h -V --lsusb --tree --vidpid --show --device --filter-name --filter-serial --filter-class --filter-exclude --verbose --blocks --bus-blocks --config-blocks --interface-blocks --endpoint-blocks --block-operation --more --sort-devices --sort-buses --group-devices --hide-buses --hide-hubs --list-root-hubs --decimal --no-padding --color --no-color --encoding --ascii --no-icons --icon --headings --json --from-json --force-libusb --config --filter-post --debug --mask-serials --gen --system-profiler --help --version watch help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -75,6 +75,10 @@ _cyme() {
                     ;;
                 --filter-class)
                     COMPREPLY=($(compgen -W "use-interface-descriptor audio cdc-communications hid physical image printer mass-storage hub cdc-data smart-card content-security video personal-healthcare audio-video billboard usb-type-c-bridge bdp mctp i3c-device diagnostic wireless-controller miscellaneous application-specific-interface vendor-specific-class" -- "${cur}"))
+                    return 0
+                    ;;
+                --filter-exclude)
+                    COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
                 --blocks)

--- a/doc/cyme.fish
+++ b/doc/cyme.fish
@@ -1,6 +1,6 @@
 # Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
 function __fish_cyme_global_optspecs
-	string join \n l/lsusb t/tree d/vidpid= s/show= D/device= filter-name= filter-serial= filter-class= v/verbose b/blocks= bus-blocks= config-blocks= interface-blocks= endpoint-blocks= block-operation= m/more sort-devices= sort-buses group-devices= hide-buses hide-hubs list-root-hubs decimal no-padding color= no-color encoding= ascii no-icons icon= headings json from-json= F/force-libusb c/config= filter-post z/debug mask-serials= gen system-profiler h/help V/version
+	string join \n l/lsusb t/tree d/vidpid= s/show= D/device= filter-name= filter-serial= filter-class= filter-exclude= v/verbose b/blocks= bus-blocks= config-blocks= interface-blocks= endpoint-blocks= block-operation= m/more sort-devices= sort-buses group-devices= hide-buses hide-hubs list-root-hubs decimal no-padding color= no-color encoding= ascii no-icons icon= headings json from-json= F/force-libusb c/config= filter-post z/debug mask-serials= gen system-profiler h/help V/version
 end
 
 function __fish_cyme_needs_command
@@ -54,6 +54,7 @@ wireless-controller\t'Wireless controllers: Bluetooth adaptors, Microsoft RNDIS'
 miscellaneous\t'This base class is defined for miscellaneous device definitions. Some matching SubClass and Protocols are defined on the USB-IF website'
 application-specific-interface\t'This base class is defined for devices that conform to several class specifications found on the USB-IF website'
 vendor-specific-class\t'This base class is defined for vendors to use as they please'"
+complete -c cyme -n "__fish_cyme_needs_command" -l filter-exclude -d 'Exclude devices matching KEY=VALUE criteria. KEY is one of: vidpid, name, serial, class, bus, number. Comma-separate multiple KEY=VALUE pairs to AND them (one occurrence). Repeat the arg to OR exclusions' -r
 complete -c cyme -n "__fish_cyme_needs_command" -s b -l blocks -d 'Specify the blocks which will be displayed for each device and in what order. Supply arg multiple times or csv to specify multiple blocks' -r -f -a "bus-number\t'Number of bus device is attached'
 device-number\t'Bus issued device number'
 branch-position\t'Position of device in parent branch'

--- a/doc/cyme_example_config.json
+++ b/doc/cyme_example_config.json
@@ -115,5 +115,6 @@
   "force-libusb": false,
   "json": false,
   "print-non-critical-profiler-stderr": false,
-  "device-filter": null
+  "filter-include": [],
+  "filter-exclude": []
 }

--- a/doc/cyme_example_config.json
+++ b/doc/cyme_example_config.json
@@ -114,5 +114,6 @@
   "headings": false,
   "force-libusb": false,
   "json": false,
-  "print-non-critical-profiler-stderr": false
+  "print-non-critical-profiler-stderr": false,
+  "filter": null
 }

--- a/doc/cyme_example_config.json
+++ b/doc/cyme_example_config.json
@@ -115,5 +115,5 @@
   "force-libusb": false,
   "json": false,
   "print-non-critical-profiler-stderr": false,
-  "filter": null
+  "device-filter": null
 }

--- a/doc/cyme_example_filter_config.json
+++ b/doc/cyme_example_filter_config.json
@@ -57,7 +57,7 @@
   "force-libusb": false,
   "json": false,
   "print-non-critical-profiler-stderr": false,
-  "filter": {
+  "device-filter": {
     "filters": [
       {
         "vid": 7504,

--- a/doc/cyme_example_filter_config.json
+++ b/doc/cyme_example_filter_config.json
@@ -1,0 +1,98 @@
+{
+  "icons": {
+    "user": null,
+    "tree": null
+  },
+  "colours": {
+    "name": "bright blue",
+    "serial": "green",
+    "manufacturer": "blue",
+    "driver": "bright magenta",
+    "string": "blue",
+    "icon": null,
+    "location": "magenta",
+    "path": "bright cyan",
+    "number": "cyan",
+    "speed": "magenta",
+    "vid": "bright yellow",
+    "pid": "yellow",
+    "class_code": "bright yellow",
+    "sub_code": "yellow",
+    "protocol": "yellow",
+    "attributes": "magenta",
+    "power": "red",
+    "tree": "bright black",
+    "tree_bus_start": "bright black",
+    "tree_bus_terminator": "bright black",
+    "tree_configuration_terminator": "bright black",
+    "tree_interface_terminator": "bright black",
+    "tree_endpoint_in": "yellow",
+    "tree_endpoint_out": "magenta"
+  },
+  "blocks": null,
+  "bus-blocks": null,
+  "config-blocks": null,
+  "interface-blocks": null,
+  "endpoint-blocks": null,
+  "block-operation": null,
+  "mask-serials": null,
+  "group-devices": null,
+  "encoding": null,
+  "icon-when": null,
+  "color-when": null,
+  "sort-devices": null,
+  "sort-buses": false,
+  "max-variable-string-len": null,
+  "no-auto-width": false,
+  "lsusb": false,
+  "tree": false,
+  "verbose": 0,
+  "more": false,
+  "hide-buses": false,
+  "hide-hubs": false,
+  "list-root-hubs": false,
+  "decimal": false,
+  "no-padding": false,
+  "headings": false,
+  "force-libusb": false,
+  "json": false,
+  "print-non-critical-profiler-stderr": false,
+  "filter": {
+    "filters": [
+      {
+        "vid": 7504,
+        "pid": 24600
+      },
+      {
+        "vid": 1452
+      },
+      {
+        "name": "black magic"
+      },
+      {
+        "class": "hid"
+      },
+      {
+        "vid": 4966,
+        "name": "J-Link",
+        "case_sensitive": true
+      },
+      {
+        "bus": 1,
+        "number": 3
+      }
+    ],
+    "exclude-filters": [
+      {
+        "name": "Hub"
+      },
+      {
+        "vid": 7531,
+        "pid": 2
+      }
+    ],
+    "exclude-empty-bus": false,
+    "exclude-empty-hub": false,
+    "no-exclude-root-hub": false
+  }
+}

--- a/doc/cyme_example_filter_config.json
+++ b/doc/cyme_example_filter_config.json
@@ -57,42 +57,38 @@
   "force-libusb": false,
   "json": false,
   "print-non-critical-profiler-stderr": false,
-  "device-filter": {
-    "filters": [
-      {
-        "vid": 7504,
-        "pid": 24600
-      },
-      {
-        "vid": 1452
-      },
-      {
-        "name": "black magic"
-      },
-      {
-        "class": "hid"
-      },
-      {
-        "vid": 4966,
-        "name": "J-Link",
-        "case_sensitive": true
-      },
-      {
-        "bus": 1,
-        "number": 3
-      }
-    ],
-    "exclude-filters": [
-      {
-        "name": "Hub"
-      },
-      {
-        "vid": 7531,
-        "pid": 2
-      }
-    ],
-    "exclude-empty-bus": false,
-    "exclude-empty-hub": false,
-    "no-exclude-root-hub": false
-  }
+  "filter-include": [
+    {
+      "vidpid": "1d50:6018"
+    },
+    {
+      "vidpid": "05ac"
+    },
+    {
+      "name": "black magic"
+    },
+    {
+      "class": "hid"
+    },
+    {
+      "vidpid": "1366",
+      "name": "J-Link"
+    },
+    {
+      "bus": 1,
+      "number": 3
+    }
+  ],
+  "filter-exclude": [
+    {
+      "name": "Hub"
+    },
+    {
+      "serial": "zf3ds2",
+      "case-sensitive": true
+    },
+    {
+      "vidpid": "1d6b:0002"
+    }
+  ]
 }

--- a/examples/filter_devices.rs
+++ b/examples/filter_devices.rs
@@ -1,7 +1,7 @@
-/// This example shows how to use the Filter to filter out devices that match a certain criteria
+/// This example shows how to use the FilterGroup to filter out devices that match certain criteria
 ///
-/// See [`Filter`] docs for more information
-use cyme::profiler::{self, Filter};
+/// See [`FilterGroup`] docs for more information
+use cyme::profiler::{self, Filter, FilterGroup};
 use cyme::usb::BaseClass;
 
 fn main() -> Result<(), String> {
@@ -9,11 +9,8 @@ fn main() -> Result<(), String> {
     let mut sp_usb = profiler::get_spusb()
         .map_err(|e| format!("Failed to gather system USB data from libusb, Error({e})"))?;
 
-    // if one does want the tree, use the utility
-    let filter = Filter {
-        class: Some(BaseClass::Hid),
-        ..Default::default()
-    };
+    // create a filter group with a single filter that matches devices with the HID class
+    let filter = FilterGroup::from(Filter::new_with_class(BaseClass::Hid));
 
     // will retain only the buses that have devices that match the filter - parent devices such as hubs with a HID device will be retained
     filter.retain_buses(&mut sp_usb.buses);
@@ -23,7 +20,6 @@ fn main() -> Result<(), String> {
 
     // if one does not care about the tree, flatten the devices and do manually
     // let hid_devices = sp_usb.flatten_devices().iter().filter(|d| d.class == Some(BaseClass::HID));
-
     if sp_usb.buses.is_empty() {
         println!("No HID devices found");
     } else {

--- a/examples/filter_devices.rs
+++ b/examples/filter_devices.rs
@@ -1,7 +1,7 @@
-/// This example shows how to use the FilterGroup to filter out devices that match certain criteria
+/// This example shows how to use the DeviceFilter to filter out devices that match certain criteria
 ///
-/// See [`FilterGroup`] docs for more information
-use cyme::profiler::{self, Filter, FilterGroup};
+/// See [`DeviceFilter`] docs for more information
+use cyme::profiler::{self, Filter, DeviceFilter};
 use cyme::usb::BaseClass;
 
 fn main() -> Result<(), String> {
@@ -10,7 +10,7 @@ fn main() -> Result<(), String> {
         .map_err(|e| format!("Failed to gather system USB data from libusb, Error({e})"))?;
 
     // create a filter group with a single filter that matches devices with the HID class
-    let filter = FilterGroup::from(Filter::new_with_class(BaseClass::Hid));
+    let filter = DeviceFilter::from(Filter::new_with_class(BaseClass::Hid));
 
     // will retain only the buses that have devices that match the filter - parent devices such as hubs with a HID device will be retained
     filter.retain_buses(&mut sp_usb.buses);

--- a/examples/filter_devices.rs
+++ b/examples/filter_devices.rs
@@ -1,7 +1,7 @@
 /// This example shows how to use the DeviceFilter to filter out devices that match certain criteria
 ///
 /// See [`DeviceFilter`] docs for more information
-use cyme::profiler::{self, Filter, DeviceFilter};
+use cyme::profiler::{self, DeviceFilter, Filter};
 use cyme::usb::BaseClass;
 
 fn main() -> Result<(), String> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -89,8 +89,12 @@ pub struct Config {
     pub json: bool,
     /// Print non-critical errors (normally due to permissions) during USB profiler to stderr
     pub print_non_critical_profiler_stderr: bool,
-    /// Default device filter to apply when running cyme
-    pub device_filter: Option<crate::profiler::DeviceFilter>,
+    /// Inclusion filters, OR'd together. Each entry is a [`crate::profiler::FilterEntry`];
+    /// fields within one entry are AND'd, multiple entries are OR'd.
+    pub filter_include: Vec<crate::profiler::FilterEntry>,
+    /// Exclusion filters, OR'd together. Devices matching any entry are hidden even if
+    /// they passed an inclusion filter.
+    pub filter_exclude: Vec<crate::profiler::FilterEntry>,
 }
 
 impl Config {
@@ -152,55 +156,67 @@ impl Config {
         }
     }
 
-    /// Get an example [`Config`] with a verbose [`crate::profiler::DeviceFilter`] demonstrating all filter fields
+    /// Get an example [`Config`] demonstrating the filter string syntax
     ///
-    /// Intended for generating `cyme_example_filter_config.json` (see `--gen`). The filter
-    /// is written inline so every field is visible and users can copy/adapt what they need.
+    /// Intended for generating `cyme_example_filter_config.json` (see `--gen`).
     /// Unlike [`Config::example`] this is not intended as a base config to copy verbatim.
     pub fn example_with_filter() -> Self {
-        use crate::profiler::{DeviceFilter, Filter};
+        use crate::profiler::{FilterEntry, VidPid};
         use crate::usb::BaseClass;
 
         Config {
-            device_filter: Some(DeviceFilter {
-                // Inclusion filters are OR'd: a device passes if it matches any one.
-                filters: vec![
-                    // Specific device by vendor and product ID (decimal u16 values in JSON)
-                    Filter::new_with_vid_pid(0x1d50, 0x6018),
-                    // Vendor only — omit pid to match any product from this vendor
-                    Filter {
-                        vid: Some(0x05ac),
-                        ..Default::default()
-                    },
-                    // Name substring — case-insensitive when all-lowercase, case-sensitive otherwise
-                    Filter::new_with_name("black magic".into(), false),
-                    // USB class code
-                    Filter::new_with_class(BaseClass::Hid),
-                    // AND within a filter: vid AND name must both match (case_sensitive true = exact case)
-                    Filter {
-                        vid: Some(0x1366),
-                        name: Some("J-Link".into()),
-                        case_sensitive: true,
-                        ..Default::default()
-                    },
-                    // Physical location: bus and device number
-                    Filter::new_with_bus_number(1, 3),
-                ],
-                // Exclusion filters: device is hidden if it matches any one of these,
-                // even when it satisfied an inclusion filter above.
-                exclude_filters: vec![
-                    // Hide devices whose name contains "Hub" (capital H → case-sensitive)
-                    Filter::new_with_name("Hub".into(), false),
-                    // Hide a specific vid:pid
-                    Filter::new_with_vid_pid(0x1d6b, 0x0002),
-                ],
-                // Hide buses that contain no devices
-                exclude_empty_bus: false,
-                // Hide hubs that contain no devices (when listing, hides all hubs)
-                exclude_empty_hub: false,
-                // On Linux root hub devices are excluded by default; true to include them
-                no_exclude_root_hub: false,
-            }),
+            filter_include: vec![
+                // Match a specific device by vid:pid
+                FilterEntry {
+                    vidpid: Some(VidPid(Some(0x1d50), Some(0x6018))),
+                    ..Default::default()
+                },
+                // Match any device from a vendor (vid only, pid wildcard)
+                FilterEntry {
+                    vidpid: Some(VidPid(Some(0x05ac), None)),
+                    ..Default::default()
+                },
+                // Match by name substring (all-lowercase = case-insensitive)
+                FilterEntry {
+                    name: Some("black magic".into()),
+                    ..Default::default()
+                },
+                // Match by USB class
+                FilterEntry {
+                    class: Some(BaseClass::Hid),
+                    ..Default::default()
+                },
+                // AND within one entry: vid AND name must both match (capitalization = case-sensitive)
+                FilterEntry {
+                    vidpid: Some(VidPid(Some(0x1366), None)),
+                    name: Some("J-Link".into()),
+                    ..Default::default()
+                },
+                // Match by physical location
+                FilterEntry {
+                    bus: Some(1),
+                    number: Some(3),
+                    ..Default::default()
+                },
+            ],
+            filter_exclude: vec![
+                // Hide devices whose name contains "Hub" (capital H = case-sensitive)
+                FilterEntry {
+                    name: Some("Hub".into()),
+                    ..Default::default()
+                },
+                // Exclude device with serial number containing "zf3ds2" (case-sensitive)
+                FilterEntry {
+                    serial: Some("zf3ds2".into()),
+                    case_sensitive: true,
+                    ..Default::default()
+                },
+                // Hide a specific vid:pid
+                FilterEntry {
+                    vidpid: Some(VidPid(Some(0x1d6b), Some(0x0002))),
+                    ..Default::default()
+                },
+            ],
             ..Default::default()
         }
     }
@@ -371,12 +387,25 @@ impl From<&Config> for display::PrintSettings {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::profiler::{FilterEntry, VidPid};
 
     #[test]
     #[cfg(feature = "regex_icon")]
     fn test_deserialize_example_file() {
         let path = PathBuf::from("./doc").join("cyme_example_config.json");
         assert!(Config::from_file(path).is_ok());
+    }
+
+    #[test]
+    #[cfg(feature = "regex_icon")]
+    fn test_deserialize_example_filter_file() {
+        let path = PathBuf::from("./doc").join("cyme_example_filter_config.json");
+        let c = Config::from_file(path);
+        assert!(
+            c.is_ok(),
+            "Failed to deserialize example filter config: {:?}",
+            c.err()
+        );
     }
 
     #[test]
@@ -402,35 +431,55 @@ mod tests {
 
     #[test]
     fn test_filter_serialize_deserialize() {
-        use crate::profiler::{DeviceFilter, Filter};
-
         let config = Config {
-            device_filter: Some(DeviceFilter {
-                filters: vec![Filter {
-                    vid: Some(0x1d50),
-                    pid: Some(0x6018),
+            filter_include: vec![
+                FilterEntry {
+                    vidpid: Some(VidPid(Some(0x1d50), Some(0x6018))),
                     ..Default::default()
-                }],
-                exclude_filters: vec![Filter {
-                    name: Some("Keyboard".into()),
+                },
+                FilterEntry {
+                    name: Some("black magic".into()),
                     ..Default::default()
-                }],
+                },
+            ],
+            filter_exclude: vec![FilterEntry {
+                name: Some("Keyboard".into()),
                 ..Default::default()
-            }),
+            }],
             ..Default::default()
         };
 
         // round-trip through JSON
         let json = serde_json::to_string(&config).unwrap();
         let restored: Config = serde_json::from_str(&json).unwrap();
-        assert_eq!(config.device_filter, restored.device_filter);
+        assert_eq!(config.filter_include, restored.filter_include);
+        assert_eq!(config.filter_exclude, restored.filter_exclude);
 
-        // deserialize from raw JSON — note kebab-case key and decimal VID/PID values
-        let raw = r#"{"device-filter": {"filters": [{"vid": 7504, "pid": 24600}], "exclude-filters": [{"name": "Keyboard"}]}}"#;
+        // deserialize from raw JSON — vidpid as hex string, other fields as plain strings
+        let raw = r#"{"filter-include": [{"vidpid": "1d50:6018"}, {"name": "black magic"}], "filter-exclude": [{"name": "Keyboard"}]}"#;
         let from_raw: Config = serde_json::from_str(raw).unwrap();
-        let f = from_raw.device_filter.unwrap();
-        assert_eq!(f.filters[0].vid, Some(0x1d50));
-        assert_eq!(f.filters[0].pid, Some(0x6018));
-        assert_eq!(f.exclude_filters[0].name.as_deref(), Some("Keyboard"));
+        assert_eq!(
+            from_raw.filter_include[0].vidpid,
+            Some(VidPid(Some(0x1d50), Some(0x6018)))
+        );
+        assert_eq!(
+            from_raw.filter_include[1].name.as_deref(),
+            Some("black magic")
+        );
+        assert_eq!(from_raw.filter_exclude[0].name.as_deref(), Some("Keyboard"));
+
+        // vid-only and AND within one entry
+        let raw = r#"{"filter-include": [{"vidpid": "05ac", "name": "Keyboard"}]}"#;
+        let from_raw: Config = serde_json::from_str(raw).unwrap();
+        assert_eq!(
+            from_raw.filter_include[0].vidpid,
+            Some(VidPid(Some(0x05ac), None))
+        );
+        assert_eq!(from_raw.filter_include[0].name.as_deref(), Some("Keyboard"));
+
+        // invalid vidpid string should fail
+        assert!(
+            serde_json::from_str::<Config>(r#"{"filter-include": [{"vidpid": "gggg"}]}"#).is_err()
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -152,6 +152,59 @@ impl Config {
         }
     }
 
+    /// Get an example [`Config`] with a verbose [`crate::profiler::DeviceFilter`] demonstrating all filter fields
+    ///
+    /// Intended for generating `cyme_example_filter_config.json` (see `--gen`). The filter
+    /// is written inline so every field is visible and users can copy/adapt what they need.
+    /// Unlike [`Config::example`] this is not intended as a base config to copy verbatim.
+    pub fn example_with_filter() -> Self {
+        use crate::profiler::{DeviceFilter, Filter};
+        use crate::usb::BaseClass;
+
+        Config {
+            filter: Some(DeviceFilter {
+                // Inclusion filters are OR'd: a device passes if it matches any one.
+                filters: vec![
+                    // Specific device by vendor and product ID (decimal u16 values in JSON)
+                    Filter::new_with_vid_pid(0x1d50, 0x6018),
+                    // Vendor only — omit pid to match any product from this vendor
+                    Filter {
+                        vid: Some(0x05ac),
+                        ..Default::default()
+                    },
+                    // Name substring — case-insensitive when all-lowercase, case-sensitive otherwise
+                    Filter::new_with_name("black magic".into(), false),
+                    // USB class code
+                    Filter::new_with_class(BaseClass::Hid),
+                    // AND within a filter: vid AND name must both match (case_sensitive true = exact case)
+                    Filter {
+                        vid: Some(0x1366),
+                        name: Some("J-Link".into()),
+                        case_sensitive: true,
+                        ..Default::default()
+                    },
+                    // Physical location: bus and device number
+                    Filter::new_with_bus_number(1, 3),
+                ],
+                // Exclusion filters: device is hidden if it matches any one of these,
+                // even when it satisfied an inclusion filter above.
+                exclude_filters: vec![
+                    // Hide devices whose name contains "Hub" (capital H → case-sensitive)
+                    Filter::new_with_name("Hub".into(), false),
+                    // Hide a specific vid:pid
+                    Filter::new_with_vid_pid(0x1d6b, 0x0002),
+                ],
+                // Hide buses that contain no devices
+                exclude_empty_bus: false,
+                // Hide hubs that contain no devices (when listing, hides all hubs)
+                exclude_empty_hub: false,
+                // On Linux root hub devices are excluded by default; true to include them
+                no_exclude_root_hub: false,
+            }),
+            ..Default::default()
+        }
+    }
+
     /// Attempt to read from .json format config at `file_path`
     pub fn from_file<P: AsRef<Path>>(file_path: P) -> Result<Self> {
         let f = File::open(&file_path)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -89,6 +89,8 @@ pub struct Config {
     pub json: bool,
     /// Print non-critical errors (normally due to permissions) during USB profiler to stderr
     pub print_non_critical_profiler_stderr: bool,
+    /// Default filter group to apply when running cyme
+    pub filter: Option<crate::profiler::FilterGroup>,
 }
 
 impl Config {
@@ -343,5 +345,39 @@ mod tests {
         let c = Config::new();
         assert!(c.save_file(&path).is_ok());
         assert!(Config::from_file(path).is_ok());
+    }
+
+    #[test]
+    fn test_filter_serialize_deserialize() {
+        use crate::profiler::{Filter, FilterGroup};
+
+        let config = Config {
+            filter: Some(FilterGroup {
+                filters: vec![Filter {
+                    vid: Some(0x1d50),
+                    pid: Some(0x6018),
+                    ..Default::default()
+                }],
+                exclude_filters: vec![Filter {
+                    name: Some("Keyboard".into()),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        // round-trip through JSON
+        let json = serde_json::to_string(&config).unwrap();
+        let restored: Config = serde_json::from_str(&json).unwrap();
+        assert_eq!(config.filter, restored.filter);
+
+        // deserialize from raw JSON — note kebab-case key and decimal VID/PID values
+        let raw = r#"{"filter": {"filters": [{"vid": 7504, "pid": 24600}], "exclude-filters": [{"name": "Keyboard"}]}}"#;
+        let from_raw: Config = serde_json::from_str(raw).unwrap();
+        let f = from_raw.filter.unwrap();
+        assert_eq!(f.filters[0].vid, Some(0x1d50));
+        assert_eq!(f.filters[0].pid, Some(0x6018));
+        assert_eq!(f.exclude_filters[0].name.as_deref(), Some("Keyboard"));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,9 @@ use crate::display;
 use crate::display::Block;
 use crate::error::{Error, ErrorKind, Result};
 use crate::icon;
+use crate::profiler::FilterEntry;
+use crate::types::VidPid;
+use crate::usb::BaseClass;
 
 const CONF_DIR: &str = "cyme";
 const CONF_NAME: &str = "cyme.json";
@@ -161,9 +164,6 @@ impl Config {
     /// Intended for generating `cyme_example_filter_config.json` (see `--gen`).
     /// Unlike [`Config::example`] this is not intended as a base config to copy verbatim.
     pub fn example_with_filter() -> Self {
-        use crate::profiler::{FilterEntry, VidPid};
-        use crate::usb::BaseClass;
-
         Config {
             filter_include: vec![
                 // Match a specific device by vid:pid
@@ -387,7 +387,6 @@ impl From<&Config> for display::PrintSettings {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::profiler::{FilterEntry, VidPid};
 
     #[test]
     #[cfg(feature = "regex_icon")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -90,7 +90,7 @@ pub struct Config {
     /// Print non-critical errors (normally due to permissions) during USB profiler to stderr
     pub print_non_critical_profiler_stderr: bool,
     /// Default filter group to apply when running cyme
-    pub filter: Option<crate::profiler::FilterGroup>,
+    pub filter: Option<crate::profiler::DeviceFilter>,
 }
 
 impl Config {
@@ -349,10 +349,10 @@ mod tests {
 
     #[test]
     fn test_filter_serialize_deserialize() {
-        use crate::profiler::{Filter, FilterGroup};
+        use crate::profiler::{Filter, DeviceFilter};
 
         let config = Config {
-            filter: Some(FilterGroup {
+            filter: Some(DeviceFilter {
                 filters: vec![Filter {
                     vid: Some(0x1d50),
                     pid: Some(0x6018),

--- a/src/config.rs
+++ b/src/config.rs
@@ -90,7 +90,7 @@ pub struct Config {
     /// Print non-critical errors (normally due to permissions) during USB profiler to stderr
     pub print_non_critical_profiler_stderr: bool,
     /// Default device filter to apply when running cyme
-    pub filter: Option<crate::profiler::DeviceFilter>,
+    pub device_filter: Option<crate::profiler::DeviceFilter>,
 }
 
 impl Config {
@@ -162,7 +162,7 @@ impl Config {
         use crate::usb::BaseClass;
 
         Config {
-            filter: Some(DeviceFilter {
+            device_filter: Some(DeviceFilter {
                 // Inclusion filters are OR'd: a device passes if it matches any one.
                 filters: vec![
                     // Specific device by vendor and product ID (decimal u16 values in JSON)
@@ -405,7 +405,7 @@ mod tests {
         use crate::profiler::{DeviceFilter, Filter};
 
         let config = Config {
-            filter: Some(DeviceFilter {
+            device_filter: Some(DeviceFilter {
                 filters: vec![Filter {
                     vid: Some(0x1d50),
                     pid: Some(0x6018),
@@ -423,12 +423,12 @@ mod tests {
         // round-trip through JSON
         let json = serde_json::to_string(&config).unwrap();
         let restored: Config = serde_json::from_str(&json).unwrap();
-        assert_eq!(config.filter, restored.filter);
+        assert_eq!(config.device_filter, restored.device_filter);
 
         // deserialize from raw JSON — note kebab-case key and decimal VID/PID values
-        let raw = r#"{"filter": {"filters": [{"vid": 7504, "pid": 24600}], "exclude-filters": [{"name": "Keyboard"}]}}"#;
+        let raw = r#"{"device-filter": {"filters": [{"vid": 7504, "pid": 24600}], "exclude-filters": [{"name": "Keyboard"}]}}"#;
         let from_raw: Config = serde_json::from_str(raw).unwrap();
-        let f = from_raw.filter.unwrap();
+        let f = from_raw.device_filter.unwrap();
         assert_eq!(f.filters[0].vid, Some(0x1d50));
         assert_eq!(f.filters[0].pid, Some(0x6018));
         assert_eq!(f.exclude_filters[0].name.as_deref(), Some("Keyboard"));

--- a/src/config.rs
+++ b/src/config.rs
@@ -89,7 +89,7 @@ pub struct Config {
     pub json: bool,
     /// Print non-critical errors (normally due to permissions) during USB profiler to stderr
     pub print_non_critical_profiler_stderr: bool,
-    /// Default filter group to apply when running cyme
+    /// Default device filter to apply when running cyme
     pub filter: Option<crate::profiler::DeviceFilter>,
 }
 
@@ -349,7 +349,7 @@ mod tests {
 
     #[test]
     fn test_filter_serialize_deserialize() {
-        use crate::profiler::{Filter, DeviceFilter};
+        use crate::profiler::{DeviceFilter, Filter};
 
         let config = Config {
             filter: Some(DeviceFilter {

--- a/src/display.rs
+++ b/src/display.rs
@@ -17,7 +17,7 @@ use unicode_width::UnicodeWidthStr;
 use crate::colour;
 use crate::error::Result;
 use crate::icon;
-use crate::profiler::{Bus, Device, FilterGroup, SystemProfile};
+use crate::profiler::{Bus, Device, DeviceFilter, SystemProfile};
 use crate::types::NumericalUnit;
 use crate::usb::{
     path::ConfigurationPath, path::DevicePath, path::EndpointPath, path::PortPath,
@@ -3501,7 +3501,7 @@ pub fn mask_serial(device: &mut Device, hide: &MaskSerial, recursive: bool) {
 }
 
 /// Main cyme bin prepare for printing function - changes mutable `sp_usb` with requested `filter` and sort in `settings`
-pub fn prepare(sp_usb: &mut SystemProfile, filter: Option<&FilterGroup>, settings: &PrintSettings) {
+pub fn prepare(sp_usb: &mut SystemProfile, filter: Option<&DeviceFilter>, settings: &PrintSettings) {
     // if not printing tree, hard flatten now before filtering as filter will retain non-matching parents with matching devices in tree
     // flattening now will also mean hubs will be removed when listing if `hide_hubs` because they will appear empty and sorting will be in bus -> device order rather than tree position
     log::debug!("Running prepare pre-printing");

--- a/src/display.rs
+++ b/src/display.rs
@@ -17,7 +17,7 @@ use unicode_width::UnicodeWidthStr;
 use crate::colour;
 use crate::error::Result;
 use crate::icon;
-use crate::profiler::{Bus, Device, Filter, SystemProfile};
+use crate::profiler::{Bus, Device, FilterGroup, SystemProfile};
 use crate::types::NumericalUnit;
 use crate::usb::{
     path::ConfigurationPath, path::DevicePath, path::EndpointPath, path::PortPath,
@@ -3501,7 +3501,7 @@ pub fn mask_serial(device: &mut Device, hide: &MaskSerial, recursive: bool) {
 }
 
 /// Main cyme bin prepare for printing function - changes mutable `sp_usb` with requested `filter` and sort in `settings`
-pub fn prepare(sp_usb: &mut SystemProfile, filter: Option<&Filter>, settings: &PrintSettings) {
+pub fn prepare(sp_usb: &mut SystemProfile, filter: Option<&FilterGroup>, settings: &PrintSettings) {
     // if not printing tree, hard flatten now before filtering as filter will retain non-matching parents with matching devices in tree
     // flattening now will also mean hubs will be removed when listing if `hide_hubs` because they will appear empty and sorting will be in bus -> device order rather than tree position
     log::debug!("Running prepare pre-printing");

--- a/src/display.rs
+++ b/src/display.rs
@@ -3501,7 +3501,11 @@ pub fn mask_serial(device: &mut Device, hide: &MaskSerial, recursive: bool) {
 }
 
 /// Main cyme bin prepare for printing function - changes mutable `sp_usb` with requested `filter` and sort in `settings`
-pub fn prepare(sp_usb: &mut SystemProfile, filter: Option<&DeviceFilter>, settings: &PrintSettings) {
+pub fn prepare(
+    sp_usb: &mut SystemProfile,
+    filter: Option<&DeviceFilter>,
+    settings: &PrintSettings,
+) {
     // if not printing tree, hard flatten now before filtering as filter will retain non-matching parents with matching devices in tree
     // flattening now will also mean hubs will be removed when listing if `hide_hubs` because they will appear empty and sorting will be in bus -> device order rather than tree position
     log::debug!("Running prepare pre-printing");

--- a/src/main.rs
+++ b/src/main.rs
@@ -766,26 +766,27 @@ fn build_inclusion_filters(
     serials: &[String],
     classes: &[BaseClass],
 ) -> Vec<profiler::Filter> {
-    // Normalise: empty vec → one None sentinel so cross-product still runs once
+    // Empty slice → one None sentinel so the cross-product iterates at least once;
+    // an absent dimension means "no constraint on that field".
     let vids: Vec<Option<(Option<u16>, Option<u16>)>> = if vidpids.is_empty() {
         vec![None]
     } else {
-        vidpids.iter().map(|v| Some(*v)).collect()
+        vidpids.iter().copied().map(Some).collect()
     };
-    let names: Vec<Option<String>> = if names.is_empty() {
+    let names: Vec<Option<&String>> = if names.is_empty() {
         vec![None]
     } else {
-        names.iter().map(|n| Some(n.clone())).collect()
+        names.iter().map(Some).collect()
     };
-    let serials: Vec<Option<String>> = if serials.is_empty() {
+    let serials: Vec<Option<&String>> = if serials.is_empty() {
         vec![None]
     } else {
-        serials.iter().map(|s| Some(s.clone())).collect()
+        serials.iter().map(Some).collect()
     };
     let classes: Vec<Option<BaseClass>> = if classes.is_empty() {
         vec![None]
     } else {
-        classes.iter().map(|c| Some(*c)).collect()
+        classes.iter().copied().map(Some).collect()
     };
 
     let mut filters = Vec::new();
@@ -799,8 +800,8 @@ fn build_inclusion_filters(
                         pid: pid_val,
                         bus,
                         number,
-                        name: name.clone(),
-                        serial: serial.clone(),
+                        name: name.map(|n| n.to_owned()),
+                        serial: serial.map(|s| s.to_owned()),
                         class: *class,
                         case_sensitive: false,
                     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -936,12 +936,12 @@ fn cyme() -> Result<()> {
             || !exclude_filters.is_empty()
             || config.hide_hubs
             || config.hide_buses
-            || config.filter.is_some();
+            || config.device_filter.is_some();
 
         if has_any_criteria || cfg!(target_os = "linux") {
             // Use config.filter as the base so its filters and structural flags are preserved;
             // CLI args are then layered on top.
-            let mut f = config.filter.clone().unwrap_or_default();
+            let mut f = config.device_filter.clone().unwrap_or_default();
 
             // Extend inclusion/exclusion filters with any CLI-supplied criteria (OR'd)
             if has_inclusion_criteria {

--- a/src/main.rs
+++ b/src/main.rs
@@ -630,6 +630,12 @@ fn print_man() -> Result<()> {
         serde_json::to_string_pretty(&Config::example())?,
     )?;
 
+    // example config with filter
+    std::fs::write(
+        PathBuf::from(&outdir).join("cyme_example_filter_config.json"),
+        serde_json::to_string_pretty(&Config::example_with_filter())?,
+    )?;
+
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 //! Where the magic happens for `cyme` binary!
-#[cfg(not(feature = "watch"))]
-use clap::Parser;
 #[cfg(feature = "watch")]
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
+#[cfg(not(feature = "watch"))]
+use clap::{Parser, ValueEnum};
 use colored::*;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -37,8 +37,8 @@ struct Args {
     tree: bool,
 
     /// Show only devices with the specified vendor and product ID numbers (in hexadecimal) in format VID:[PID]
-    #[arg(short = 'd', long)]
-    vidpid: Option<String>,
+    #[arg(short = 'd', long, action = clap::ArgAction::Append, value_name = "VID:[PID]")]
+    vidpid: Vec<String>,
 
     /// Show only devices with specified device and/or bus numbers (in decimal) in format [[bus]:][devnum]
     #[arg(short, long)]
@@ -49,16 +49,21 @@ struct Args {
     device: Option<String>,
 
     /// Filter on string contained in name
-    #[arg(long)]
-    filter_name: Option<String>,
+    #[arg(long, action = clap::ArgAction::Append)]
+    filter_name: Vec<String>,
 
     /// Filter on string contained in serial
-    #[arg(long)]
-    filter_serial: Option<String>,
+    #[arg(long, action = clap::ArgAction::Append)]
+    filter_serial: Vec<String>,
 
     /// Filter on USB class code
-    #[arg(long)]
-    filter_class: Option<BaseClass>,
+    #[arg(long, action = clap::ArgAction::Append)]
+    filter_class: Vec<BaseClass>,
+
+    /// Exclude devices matching KEY=VALUE criteria. KEY is one of: vidpid, name, serial, class, bus, number.
+    /// Comma-separate multiple KEY=VALUE pairs to AND them (one occurrence). Repeat the arg to OR exclusions.
+    #[arg(long, action = clap::ArgAction::Append, value_name = "KEY=VALUE")]
+    filter_exclude: Vec<String>,
 
     /// Verbosity level (repeat provides count): 1 prints device configurations; 2 prints interfaces; 3 prints interface endpoints; 4 prints everything and more blocks
     #[arg(short = 'v', long, default_value_t = 0, action = clap::ArgAction::Count)]
@@ -370,6 +375,52 @@ fn parse_show(s: &str) -> Result<(Option<u8>, Option<u8>)> {
     }
 }
 
+/// Parse a --filter-exclude KEY=VALUE[,KEY=VALUE...] string into a Filter
+fn parse_exclude(s: &str) -> Result<profiler::Filter> {
+    let mut f = profiler::Filter::default();
+    for part in s.split(',') {
+        let (key, value) = part.split_once('=').ok_or_else(|| {
+            Error::new(
+                ErrorKind::InvalidArg,
+                &format!("Expected KEY=VALUE format in '--filter-exclude {s}'"),
+            )
+        })?;
+        match key.trim() {
+            "vidpid" => {
+                let (vid, pid) = parse_vidpid(value.trim())?;
+                f.vid = vid;
+                f.pid = pid;
+            }
+            "name" => f.name = Some(value.to_string()),
+            "serial" => f.serial = Some(value.to_string()),
+            "class" => {
+                f.class = Some(
+                    BaseClass::from_str(value.trim(), true).map_err(|e| {
+                        Error::new(ErrorKind::Parsing, &e.to_string())
+                    })?,
+                )
+            }
+            "bus" => {
+                f.bus = Some(value.trim().parse::<u8>().map_err(|e| {
+                    Error::new(ErrorKind::Parsing, &e.to_string())
+                })?)
+            }
+            "number" => {
+                f.number = Some(value.trim().parse::<u8>().map_err(|e| {
+                    Error::new(ErrorKind::Parsing, &e.to_string())
+                })?)
+            }
+            _ => {
+                return Err(Error::new(
+                    ErrorKind::InvalidArg,
+                    &format!("Unknown exclude key '{key}'; expected one of: vidpid, name, serial, class, bus, number"),
+                ))
+            }
+        }
+    }
+    Ok(f)
+}
+
 /// Parse devpath supplied by --device into a show format
 ///
 /// Could be a regex match r"^[\/|\w+\/]+(?'bus'\d{3})\/(?'devno'\d{3})$" but this saves another crate
@@ -415,13 +466,13 @@ fn is_watch(args: &Args) -> bool {
 fn get_system_profile_macos(
     config: &Config,
     args: &Args,
-    filter: Option<profiler::Filter>,
+    filter: Option<profiler::FilterGroup>,
 ) -> Result<profiler::SystemProfile> {
     // if requested or only have libusb, use system_profiler and merge with libusb
     if args.system_profiler || !cfg!(feature = "nusb") {
         if !config.force_libusb
             && args.device.is_none() // device path requires extra
-                && args.filter_class.is_none() // class filter requires extra
+                && args.filter_class.is_empty() // class filter requires extra
                 && !((config.tree && config.lsusb) || config.verbose > 0 || config.more)
         {
             profiler::macos::get_spusb().map_or_else(
@@ -448,7 +499,7 @@ fn get_system_profile_macos(
             {
                 profiler::ProfileDepth::Full
             } else if config.verbose == 1
-                || args.filter_class.is_some()
+                || !args.filter_class.is_empty()
                 || config.json
                 || config.more
             {
@@ -486,7 +537,7 @@ fn get_system_profile_macos(
 fn get_system_profile(
     config: &Config,
     args: &Args,
-    filter: Option<profiler::Filter>,
+    filter: Option<profiler::FilterGroup>,
 ) -> Result<profiler::SystemProfile> {
     let depth = if config.verbose >= 2
         || (config.json && config.verbose >= 1)
@@ -495,7 +546,7 @@ fn get_system_profile(
     // watch needs full data to be able to show changes properly since only new devices are re-profiled
     {
         profiler::ProfileDepth::Full
-    } else if config.verbose == 1 || args.filter_class.is_some() || config.json || config.more {
+    } else if config.verbose == 1 || !args.filter_class.is_empty() || config.json || config.more {
         profiler::ProfileDepth::Standard
     } else {
         profiler::ProfileDepth::Identity
@@ -704,6 +755,62 @@ fn merge_blocks(config: &Config, args: &Args, settings: &mut display::PrintSetti
     Ok(())
 }
 
+/// Build inclusion filters via cross-product of multi-value args.
+/// Each unique combination of (vidpid, name, serial, class) becomes one Filter.
+/// bus/number are always AND'd into every filter (single-value).
+fn build_inclusion_filters(
+    vidpids: &[(Option<u16>, Option<u16>)],
+    bus: Option<u8>,
+    number: Option<u8>,
+    names: &[String],
+    serials: &[String],
+    classes: &[BaseClass],
+) -> Vec<profiler::Filter> {
+    // Normalise: empty vec → one None sentinel so cross-product still runs once
+    let vids: Vec<Option<(Option<u16>, Option<u16>)>> = if vidpids.is_empty() {
+        vec![None]
+    } else {
+        vidpids.iter().map(|v| Some(*v)).collect()
+    };
+    let names: Vec<Option<String>> = if names.is_empty() {
+        vec![None]
+    } else {
+        names.iter().map(|n| Some(n.clone())).collect()
+    };
+    let serials: Vec<Option<String>> = if serials.is_empty() {
+        vec![None]
+    } else {
+        serials.iter().map(|s| Some(s.clone())).collect()
+    };
+    let classes: Vec<Option<BaseClass>> = if classes.is_empty() {
+        vec![None]
+    } else {
+        classes.iter().map(|c| Some(*c)).collect()
+    };
+
+    let mut filters = Vec::new();
+    for vid in &vids {
+        for name in &names {
+            for serial in &serials {
+                for class in &classes {
+                    let (vid_val, pid_val) = vid.unwrap_or((None, None));
+                    filters.push(profiler::Filter {
+                        vid: vid_val,
+                        pid: pid_val,
+                        bus,
+                        number,
+                        name: name.clone(),
+                        serial: serial.clone(),
+                        class: *class,
+                        case_sensitive: false,
+                    });
+                }
+            }
+        }
+    }
+    filters
+}
+
 fn cyme() -> Result<()> {
     let mut args = Args::parse();
 
@@ -756,83 +863,103 @@ fn cyme() -> Result<()> {
         _ => (),
     };
 
-    let filter = if config.hide_hubs
-        || config.hide_buses
-        || args.vidpid.is_some()
-        || args.show.is_some()
-        || args.device.is_some()
-        || args.filter_name.is_some()
-        || args.filter_serial.is_some()
-        || args.filter_class.is_some()
-    {
-        let mut f = profiler::Filter::new();
+    let filter = {
+        // Parse multi-value inclusion args
+        let vidpids: Vec<(Option<u16>, Option<u16>)> = args
+            .vidpid
+            .iter()
+            .map(|s| {
+                parse_vidpid(s.as_str()).map_err(|e| {
+                    Error::new(
+                        ErrorKind::InvalidArg,
+                        &format!("Failed to parse vidpid '{s}'; Error({e})"),
+                    )
+                })
+            })
+            .collect::<Result<_>>()?;
 
-        if let Some(vidpid) = &args.vidpid {
-            let (vid, pid) = parse_vidpid(vidpid.as_str()).map_err(|e| {
-                Error::new(
-                    ErrorKind::InvalidArg,
-                    &format!("Failed to parse vidpid '{vidpid}'; Error({e})"),
-                )
-            })?;
-            f.vid = vid;
-            f.pid = pid;
-        }
-
-        // decode device devpath into the show filter since that is what it essentially will do
-        if let Some(devpath) = &args.device {
-            let (bus, number) = parse_devpath(devpath.as_str()).map_err(|e| {
+        // Parse show/device into bus/number (single-value)
+        let (bus, number) = if let Some(devpath) = &args.device {
+            parse_devpath(devpath.as_str()).map_err(|e| {
                 Error::new(
                     ErrorKind::InvalidArg,
                     &format!(
                         "Failed to parse devpath '{devpath}', should end with 'BUS/DEVNO'; Error({e})"
                     ),
                 )
-            })?;
-            f.bus = bus;
-            f.number = number;
+            })?
         } else if let Some(show) = &args.show {
-            let (bus, number) = parse_show(show.as_str()).map_err(|e| {
+            parse_show(show.as_str()).map_err(|e| {
                 Error::new(
                     ErrorKind::InvalidArg,
                     &format!("Failed to parse show parameter '{show}'; Error({e})"),
                 )
-            })?;
-            f.bus = bus;
-            f.number = number;
-        }
+            })?
+        } else {
+            (None, None)
+        };
 
-        // no need to unwrap as these are Option
-        f.name = args.filter_name.clone();
-        f.serial = args.filter_serial.clone();
-        f.class = args.filter_class;
-        f.exclude_empty_hub = config.hide_hubs;
-        f.exclude_empty_bus = config.hide_buses;
-        // exclude root hubs unless:
-        // * lsusb compat (shows root_hubs)
-        // * json - for --from-json support
-        // * list_root_hubs - user wants to see root hubs in list
-        // * device or show is some - user specifically requested a device or bus
-        f.no_exclude_root_hub = config.lsusb
+        // Parse exclusion filters
+        let exclude_filters: Vec<profiler::Filter> = args
+            .filter_exclude
+            .iter()
+            .map(|s| {
+                parse_exclude(s.as_str()).map_err(|e| {
+                    Error::new(
+                        ErrorKind::InvalidArg,
+                        &format!("Failed to parse filter-exclude '{s}'; Error({e})"),
+                    )
+                })
+            })
+            .collect::<Result<_>>()?;
+
+        let no_exclude_root_hub = config.lsusb
             || config.json
             || config.list_root_hubs
             || args.device.is_some()
             || args.show.is_some();
 
-        Some(f)
-    } else {
-        // exclude root hubs (on Linux) unless:
-        // * lsusb compat (shows root_hubs)
-        // * json - for --from-json support
-        // * list_root_hubs - user wants to see root hubs in list
-        // * device or show is some - user specifically requested a device or bus
-        if cfg!(target_os = "linux") {
-            Some(profiler::Filter {
-                no_exclude_root_hub: (config.lsusb
-                    || config.json
-                    || config.list_root_hubs
-                    || args.device.is_some()
-                    || args.show.is_some()),
-                ..Default::default()
+        let has_inclusion_criteria = !vidpids.is_empty()
+            || !args.filter_name.is_empty()
+            || !args.filter_serial.is_empty()
+            || !args.filter_class.is_empty()
+            || bus.is_some()
+            || number.is_some();
+        let has_any_criteria = has_inclusion_criteria
+            || !exclude_filters.is_empty()
+            || config.hide_hubs
+            || config.hide_buses;
+
+        if has_any_criteria || cfg!(target_os = "linux") {
+            let inclusion_filters = if has_inclusion_criteria {
+                build_inclusion_filters(
+                    &vidpids,
+                    bus,
+                    number,
+                    &args.filter_name,
+                    &args.filter_serial,
+                    &args.filter_class,
+                )
+            } else {
+                Vec::new()
+            };
+
+            // Merge config filter if present (OR inclusion filters)
+            let mut all_inclusion_filters = inclusion_filters;
+            if let Some(cfg_filter) = &config.filter {
+                all_inclusion_filters.extend(cfg_filter.filters.iter().cloned());
+            }
+            let mut all_exclude_filters = exclude_filters;
+            if let Some(cfg_filter) = &config.filter {
+                all_exclude_filters.extend(cfg_filter.exclude_filters.iter().cloned());
+            }
+
+            Some(profiler::FilterGroup {
+                filters: all_inclusion_filters,
+                exclude_filters: all_exclude_filters,
+                exclude_empty_bus: config.hide_buses,
+                exclude_empty_hub: config.hide_hubs,
+                no_exclude_root_hub,
             })
         } else {
             None

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ struct Args {
     tree: bool,
 
     /// Show only devices with the specified vendor and product ID numbers (in hexadecimal) in format VID:[PID]
-    #[arg(short = 'd', long, action = clap::ArgAction::Append, value_name = "VID:[PID]")]
+    #[arg(short = 'd', long, action = clap::ArgAction::Append, value_name = "VID:[PID]", aliases = &["filter-vidpid"])]
     vidpid: Vec<String>,
 
     /// Show only devices with specified device and/or bus numbers (in decimal) in format [[bus]:][devnum]

--- a/src/main.rs
+++ b/src/main.rs
@@ -466,7 +466,7 @@ fn is_watch(args: &Args) -> bool {
 fn get_system_profile_macos(
     config: &Config,
     args: &Args,
-    filter: Option<profiler::FilterGroup>,
+    filter: Option<profiler::DeviceFilter>,
 ) -> Result<profiler::SystemProfile> {
     // if requested or only have libusb, use system_profiler and merge with libusb
     if args.system_profiler || !cfg!(feature = "nusb") {
@@ -537,7 +537,7 @@ fn get_system_profile_macos(
 fn get_system_profile(
     config: &Config,
     args: &Args,
-    filter: Option<profiler::FilterGroup>,
+    filter: Option<profiler::DeviceFilter>,
 ) -> Result<profiler::SystemProfile> {
     let depth = if config.verbose >= 2
         || (config.json && config.verbose >= 1)
@@ -954,7 +954,7 @@ fn cyme() -> Result<()> {
                 all_exclude_filters.extend(cfg_filter.exclude_filters.iter().cloned());
             }
 
-            Some(profiler::FilterGroup {
+            Some(profiler::DeviceFilter {
                 filters: all_inclusion_filters,
                 exclude_filters: all_exclude_filters,
                 exclude_empty_bus: config.hide_buses,

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ use cyme::display::{self, Block, DeviceBlocks};
 use cyme::error::{Error, ErrorKind, Result};
 use cyme::lsusb;
 use cyme::profiler;
+use cyme::types::VidPid;
 use cyme::usb::BaseClass;
 use std::str::FromStr;
 
@@ -39,7 +40,7 @@ struct Args {
 
     /// Show only devices with the specified vendor and product ID numbers (in hexadecimal) in format VID:[PID]
     #[arg(short = 'd', long, action = clap::ArgAction::Append, value_name = "VID:[PID]", aliases = &["filter-vidpid"])]
-    vidpid: Vec<String>,
+    vidpid: Vec<VidPid>,
 
     /// Show only devices with specified device and/or bus numbers (in decimal) in format [[bus]:][devnum]
     #[arg(short, long)]
@@ -310,11 +311,6 @@ fn merge_config(c: &mut Config, a: &Args) {
     c.verbose = c.verbose.max(a.verbose);
 }
 
-/// Parse the vidpid filter lsusb format: vid:Option<pid>
-fn parse_vidpid(s: &str) -> Result<(Option<u16>, Option<u16>)> {
-    profiler::VidPid::from_str(s).map(|v| (v.0, v.1))
-}
-
 /// Parse the show Option<bus>:device lsusb format
 fn parse_show(s: &str) -> Result<(Option<u8>, Option<u8>)> {
     if s.contains(':') {
@@ -360,9 +356,9 @@ fn parse_exclude(s: &str) -> Result<profiler::Filter> {
         })?;
         match key.trim() {
             "vidpid" => {
-                let (vid, pid) = parse_vidpid(value.trim())?;
-                f.vid = vid;
-                f.pid = pid;
+                let vp = VidPid::from_str(value.trim())?;
+                f.vid = vp.0;
+                f.pid = vp.1;
             }
             "name" => f.name = Some(value.to_string()),
             "serial" => f.serial = Some(value.to_string()),
@@ -738,7 +734,7 @@ fn merge_blocks(config: &Config, args: &Args, settings: &mut display::PrintSetti
 /// Each unique combination of (vidpid, name, serial, class) becomes one Filter.
 /// bus/number are always AND'd into every filter (single-value).
 fn build_inclusion_filters(
-    vidpids: &[(Option<u16>, Option<u16>)],
+    vidpids: &[VidPid],
     bus: Option<u8>,
     number: Option<u8>,
     names: &[String],
@@ -747,7 +743,7 @@ fn build_inclusion_filters(
 ) -> Vec<profiler::Filter> {
     // Empty slice → one None sentinel so the cross-product iterates at least once;
     // an absent dimension means "no constraint on that field".
-    let vids: Vec<Option<(Option<u16>, Option<u16>)>> = if vidpids.is_empty() {
+    let vids: Vec<Option<VidPid>> = if vidpids.is_empty() {
         vec![None]
     } else {
         vidpids.iter().copied().map(Some).collect()
@@ -773,7 +769,7 @@ fn build_inclusion_filters(
         for name in &names {
             for serial in &serials {
                 for class in &classes {
-                    let (vid_val, pid_val) = vid.unwrap_or((None, None));
+                    let (vid_val, pid_val) = vid.map_or((None, None), |v| (v.0, v.1));
                     filters.push(profiler::Filter {
                         vid: vid_val,
                         pid: pid_val,
@@ -844,19 +840,8 @@ fn cyme() -> Result<()> {
     };
 
     let filter = {
-        // Parse multi-value inclusion args
-        let vidpids: Vec<(Option<u16>, Option<u16>)> = args
-            .vidpid
-            .iter()
-            .map(|s| {
-                parse_vidpid(s.as_str()).map_err(|e| {
-                    Error::new(
-                        ErrorKind::InvalidArg,
-                        &format!("Failed to parse vidpid '{s}'; Error({e})"),
-                    )
-                })
-            })
-            .collect::<Result<_>>()?;
+        // args.vidpid is already Vec<VidPid> — parsed and validated by clap
+        let vidpids = &args.vidpid;
 
         // Parse show/device into bus/number (single-value)
         let (bus, number) = if let Some(devpath) = &args.device {
@@ -933,7 +918,7 @@ fn cyme() -> Result<()> {
             f.filters.extend(config_include);
             if has_inclusion_criteria {
                 f.filters.extend(build_inclusion_filters(
-                    &vidpids,
+                    vidpids,
                     bus,
                     number,
                     &args.filter_name,
@@ -1057,18 +1042,6 @@ mod tests {
         };
         args.blocks = Some(vec![display::DeviceBlocks::BusNumber]);
         println!("{}", serde_json::to_string_pretty(&args).unwrap());
-    }
-
-    #[test]
-    fn test_parse_vidpid() {
-        assert_eq!(
-            parse_vidpid("000A:0x000b").unwrap(),
-            (Some(0x0A), Some(0x0b))
-        );
-        assert_eq!(parse_vidpid("000A:1").unwrap(), (Some(0x0A), Some(1)));
-        assert_eq!(parse_vidpid("000A:").unwrap(), (Some(0x0A), None));
-        assert_eq!(parse_vidpid("0x000A").unwrap(), (Some(0x0A), None));
-        assert!(parse_vidpid("dfg:sdfd").is_err());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -935,39 +935,33 @@ fn cyme() -> Result<()> {
         let has_any_criteria = has_inclusion_criteria
             || !exclude_filters.is_empty()
             || config.hide_hubs
-            || config.hide_buses;
+            || config.hide_buses
+            || config.filter.is_some();
 
         if has_any_criteria || cfg!(target_os = "linux") {
-            let inclusion_filters = if has_inclusion_criteria {
-                build_inclusion_filters(
+            // Use config.filter as the base so its filters and structural flags are preserved;
+            // CLI args are then layered on top.
+            let mut f = config.filter.clone().unwrap_or_default();
+
+            // Extend inclusion/exclusion filters with any CLI-supplied criteria (OR'd)
+            if has_inclusion_criteria {
+                f.filters.extend(build_inclusion_filters(
                     &vidpids,
                     bus,
                     number,
                     &args.filter_name,
                     &args.filter_serial,
                     &args.filter_class,
-                )
-            } else {
-                Vec::new()
-            };
-
-            // Merge config filter if present (OR inclusion filters)
-            let mut all_inclusion_filters = inclusion_filters;
-            if let Some(cfg_filter) = &config.filter {
-                all_inclusion_filters.extend(cfg_filter.filters.iter().cloned());
+                ));
             }
-            let mut all_exclude_filters = exclude_filters;
-            if let Some(cfg_filter) = &config.filter {
-                all_exclude_filters.extend(cfg_filter.exclude_filters.iter().cloned());
-            }
+            f.exclude_filters.extend(exclude_filters);
 
-            Some(profiler::DeviceFilter {
-                filters: all_inclusion_filters,
-                exclude_filters: all_exclude_filters,
-                exclude_empty_bus: config.hide_buses,
-                exclude_empty_hub: config.hide_hubs,
-                no_exclude_root_hub,
-            })
+            // Structural flags: OR config.filter values with CLI/config arg values
+            f.exclude_empty_bus |= config.hide_buses;
+            f.exclude_empty_hub |= config.hide_hubs;
+            f.no_exclude_root_hub |= no_exclude_root_hub;
+
+            Some(f)
         } else {
             None
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -920,7 +920,7 @@ fn cyme() -> Result<()> {
             })
             .collect::<Result<_>>()?;
 
-        let no_exclude_root_hub = config.lsusb
+        let include_root_hubs = config.lsusb
             || config.json
             || config.list_root_hubs
             || args.device.is_some()
@@ -956,10 +956,9 @@ fn cyme() -> Result<()> {
             }
             f.exclude_filters.extend(exclude_filters);
 
-            // Structural flags: OR config.filter values with CLI/config arg values
-            f.exclude_empty_bus |= config.hide_buses;
-            f.exclude_empty_hub |= config.hide_hubs;
-            f.no_exclude_root_hub |= no_exclude_root_hub;
+            f.exclude_empty_bus = config.hide_buses;
+            f.exclude_empty_hub = config.hide_hubs;
+            f.include_root_hubs = include_root_hubs;
 
             Some(f)
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ use cyme::error::{Error, ErrorKind, Result};
 use cyme::lsusb;
 use cyme::profiler;
 use cyme::usb::BaseClass;
+use std::str::FromStr;
 
 #[cfg(feature = "watch")]
 mod watch;
@@ -311,35 +312,7 @@ fn merge_config(c: &mut Config, a: &Args) {
 
 /// Parse the vidpid filter lsusb format: vid:Option<pid>
 fn parse_vidpid(s: &str) -> Result<(Option<u16>, Option<u16>)> {
-    let vid_split: Vec<&str> = s.split(':').collect();
-    if vid_split.len() >= 2 {
-        let vid: Option<u16> =
-            vid_split
-                .first()
-                .filter(|v| !v.is_empty())
-                .map_or(Ok(None), |v| {
-                    u32::from_str_radix(v.trim().trim_start_matches("0x"), 16)
-                        .map(|v| Some(v as u16))
-                        .map_err(|e| Error::new(ErrorKind::Parsing, &e.to_string()))
-                })?;
-        let pid: Option<u16> =
-            vid_split
-                .get(1)
-                .filter(|v| !v.is_empty())
-                .map_or(Ok(None), |v| {
-                    u32::from_str_radix(v.trim().trim_start_matches("0x"), 16)
-                        .map(|v| Some(v as u16))
-                        .map_err(|e| Error::new(ErrorKind::Parsing, &e.to_string()))
-                })?;
-
-        Ok((vid, pid))
-    } else {
-        let vid: Option<u16> = u32::from_str_radix(s.trim().trim_start_matches("0x"), 16)
-            .map(|v| Some(v as u16))
-            .map_err(|e| Error::new(ErrorKind::Parsing, &e.to_string()))?;
-
-        Ok((vid, None))
-    }
+    profiler::VidPid::from_str(s).map(|v| (v.0, v.1))
 }
 
 /// Parse the show Option<bus>:device lsusb format
@@ -932,18 +905,32 @@ fn cyme() -> Result<()> {
             || !args.filter_class.is_empty()
             || bus.is_some()
             || number.is_some();
+        // Convert config FilterEntry structs to Filter (validated at config load time)
+        let config_include: Vec<profiler::Filter> = config
+            .filter_include
+            .iter()
+            .cloned()
+            .map(profiler::Filter::from)
+            .collect();
+        let config_exclude: Vec<profiler::Filter> = config
+            .filter_exclude
+            .iter()
+            .cloned()
+            .map(profiler::Filter::from)
+            .collect();
+
         let has_any_criteria = has_inclusion_criteria
             || !exclude_filters.is_empty()
             || config.hide_hubs
             || config.hide_buses
-            || config.device_filter.is_some();
+            || !config_include.is_empty()
+            || !config_exclude.is_empty();
 
         if has_any_criteria || cfg!(target_os = "linux") {
-            // Use config.filter as the base so its filters and structural flags are preserved;
-            // CLI args are then layered on top.
-            let mut f = config.device_filter.clone().unwrap_or_default();
+            let mut f = profiler::DeviceFilter::default();
 
-            // Extend inclusion/exclusion filters with any CLI-supplied criteria (OR'd)
+            // Config filters first, then CLI (both OR'd together)
+            f.filters.extend(config_include);
             if has_inclusion_criteria {
                 f.filters.extend(build_inclusion_filters(
                     &vidpids,
@@ -954,11 +941,20 @@ fn cyme() -> Result<()> {
                     &args.filter_class,
                 ));
             }
+            f.exclude_filters.extend(config_exclude);
             f.exclude_filters.extend(exclude_filters);
 
             f.exclude_empty_bus = config.hide_buses;
             f.exclude_empty_hub = config.hide_hubs;
             f.include_root_hubs = include_root_hubs;
+
+            if !f.filters.is_empty() || !f.exclude_filters.is_empty() {
+                log::info!(
+                    "Device filter active: {} inclusion filter(s), {} exclusion filter(s)",
+                    f.filters.len(),
+                    f.exclude_filters.len()
+                );
+            }
 
             Some(f)
         } else {

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -662,7 +662,7 @@ where
                 if let Some(mut root_devices) = existing {
                     // Filter root devices if needed
                     if let Some(filter) = &options.filter {
-                        root_devices.retain(|d| !d.is_root_hub() || filter.no_exclude_root_hub);
+                        root_devices.retain(|d| !d.is_root_hub() || filter.include_root_hubs);
                     }
                     root_devices.append(&mut all_devices);
                     new_bus.devices = Some(root_devices);

--- a/src/profiler/nusb.rs
+++ b/src/profiler/nusb.rs
@@ -176,13 +176,19 @@ impl From<&nusb::DeviceInfo> for Device {
             DeviceSpeed::SpeedValue(s)
         });
 
-        let manufacturer = device_info
-            .manufacturer_string()
-            .map(|s| s.to_string())
-            .or_else(|| names::vendor(device_info.vendor_id()))
-            .or_else(|| {
-                usb_ids::Vendor::from_id(device_info.vendor_id()).map(|v| v.name().to_string())
-            });
+        let manufacturer = if cfg!(target_os = "windows") {
+            // Windows does not cache manufacturer string so will always return None. We want to leave it None so that the descriptor is actually read if we can open the device
+            device_info.manufacturer_string().map(|s| s.to_string())
+        } else {
+            device_info
+                .manufacturer_string()
+                .map(|s| s.to_string())
+                .or_else(|| names::vendor(device_info.vendor_id()))
+                .or_else(|| {
+                    usb_ids::Vendor::from_id(device_info.vendor_id()).map(|v| v.name().to_string())
+                })
+        };
+
         let name = device_info
             .product_string()
             .map(|s| s.to_string())

--- a/src/profiler/nusb.rs
+++ b/src/profiler/nusb.rs
@@ -592,8 +592,7 @@ impl NusbProfiler {
             usb::DeviceDescriptor::try_from(device.handle.device_descriptor().as_bytes())?;
         sp_device.bcd_usb = Some(device_desc.usb_version);
 
-        // try to get strings from device descriptors
-        // if missing
+        // try to get strings from device descriptors if missing
         if sp_device.name.is_empty() {
             if let Some(name) = device.get_descriptor_string(device_desc.product_string_index) {
                 sp_device.name = name;

--- a/src/profiler/types.rs
+++ b/src/profiler/types.rs
@@ -1983,6 +1983,104 @@ impl<'a> IntoIterator for &'a mut Device {
     }
 }
 
+/// A vendor and product ID pair used in filter expressions, serialised as a hex string.
+///
+/// Accepts the formats `"VID:PID"`, `"VID:"`, `"VID"` (PID wildcard), or `":PID"` (VID wildcard).
+/// Both components are optional; an absent component matches any value.
+///
+/// ```
+/// use cyme::profiler::VidPid;
+/// let vp: VidPid = "1d50:6018".parse().unwrap();
+/// assert_eq!(vp, VidPid(Some(0x1d50), Some(0x6018)));
+/// let vp: VidPid = "05ac".parse().unwrap();
+/// assert_eq!(vp, VidPid(Some(0x05ac), None));
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, DeserializeFromStr, SerializeDisplay)]
+pub struct VidPid(pub Option<u16>, pub Option<u16>);
+
+impl std::fmt::Display for VidPid {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match (self.0, self.1) {
+            (Some(vid), Some(pid)) => write!(f, "{vid:04x}:{pid:04x}"),
+            (Some(vid), None) => write!(f, "{vid:04x}"),
+            (None, Some(pid)) => write!(f, ":{pid:04x}"),
+            (None, None) => write!(f, ":"),
+        }
+    }
+}
+
+impl std::str::FromStr for VidPid {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        fn parse_hex(s: &str) -> Result<u16> {
+            u16::from_str_radix(s.trim().trim_start_matches("0x"), 16)
+                .map_err(|e| Error::new(ErrorKind::Parsing, &e.to_string()))
+        }
+        if let Some((vid_str, pid_str)) = s.split_once(':') {
+            let vid = if vid_str.trim().is_empty() {
+                None
+            } else {
+                Some(parse_hex(vid_str)?)
+            };
+            let pid = if pid_str.trim().is_empty() {
+                None
+            } else {
+                Some(parse_hex(pid_str)?)
+            };
+            Ok(VidPid(vid, pid))
+        } else {
+            Ok(VidPid(Some(parse_hex(s)?), None))
+        }
+    }
+}
+
+/// A single filter entry for [`crate::config::Config`] `filter_include`/`filter_exclude` fields.
+///
+/// Each set field is AND'd together; multiple entries in the array are OR'd.
+/// Serialises to a sparse JSON object — only set fields appear.
+///
+/// ```json
+/// {"vidpid": "1d50:6018"}
+/// {"vidpid": "05ac", "name": "Keyboard"}
+/// ```
+#[skip_serializing_none]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
+pub struct FilterEntry {
+    /// Vendor and/or product ID in hex format, e.g. `"1d50:6018"`, `"05ac"`, `":6018"`
+    pub vidpid: Option<VidPid>,
+    /// Match devices whose name contains this substring
+    pub name: Option<String>,
+    /// Match devices whose serial number contains this substring
+    pub serial: Option<String>,
+    /// Match devices of this USB class
+    pub class: Option<BaseClass>,
+    /// Match devices on this bus number
+    pub bus: Option<u8>,
+    /// Match devices with this device number
+    pub number: Option<u8>,
+    /// Force case-sensitive string matching. Omit (or set `false`) to use smartcase:
+    /// case-insensitive for all-lowercase patterns, case-sensitive when the pattern has any uppercase.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub case_sensitive: bool,
+}
+
+impl From<FilterEntry> for Filter {
+    fn from(e: FilterEntry) -> Self {
+        Filter {
+            vid: e.vidpid.and_then(|v| v.0),
+            pid: e.vidpid.and_then(|v| v.1),
+            name: e.name,
+            serial: e.serial,
+            class: e.class,
+            bus: e.bus,
+            number: e.number,
+            case_sensitive: e.case_sensitive,
+        }
+    }
+}
+
 /// Used to filter devices within buses
 ///
 /// The tree to a [`Device`] is kept even if parent branches are not matches. To avoid this, one must flatten the devices first.
@@ -2004,7 +2102,11 @@ pub struct Filter {
     pub serial: Option<String>,
     /// retain only device of BaseClass class
     pub class: Option<BaseClass>,
-    /// Case sensitive matching for strings. False will be unless capital letter in query
+    /// Force case-sensitive string matching.
+    ///
+    /// When `false` (default), matching uses **smartcase**: case-insensitive if the pattern is
+    /// all-lowercase, case-sensitive if it contains any uppercase character.
+    /// Set to `true` to force case-sensitive matching even for all-lowercase patterns.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub case_sensitive: bool,
 }
@@ -2203,15 +2305,18 @@ impl Filter {
     }
 
     /// Creates a new filter with serial filter
-    pub fn new_with_serial(serial: String) -> Self {
+    pub fn new_with_serial(serial: String, case_sensitive: bool) -> Self {
         Self {
             serial: Some(serial),
+            case_sensitive,
             ..Default::default()
         }
     }
 
     fn string_match(&self, pattern: &Option<String>, query: Option<&String>) -> bool {
         if let (Some(p), Some(q)) = (pattern, query) {
+            // Smartcase: when case_sensitive=false, auto-detect from the pattern —
+            // case-sensitive if any uppercase present, case-insensitive if all-lowercase.
             let case_sensitive = if !self.case_sensitive {
                 p.chars().any(|c| c.is_uppercase())
             } else {

--- a/src/profiler/types.rs
+++ b/src/profiler/types.rs
@@ -2053,7 +2053,7 @@ impl ProfileDepth {
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct ProfilerOptions {
     /// Filter to apply during profiling
-    pub filter: Option<FilterGroup>,
+    pub filter: Option<DeviceFilter>,
     /// How much data to collect for each device
     pub depth: ProfileDepth,
     /// Whether we are building a tree (true) or just a flat list (false)
@@ -2091,7 +2091,7 @@ pub type USBFilter = Filter;
 /// use cyme::profiler::*;
 ///
 /// # let mut spusb = read_json_dump(&"./tests/data/system_profiler_dump.json").unwrap();
-/// let filter = FilterGroup::from(Filter::new_with_name("Black Magic Probe".into(), false));
+/// let filter = DeviceFilter::from(Filter::new_with_name("Black Magic Probe".into(), false));
 /// filter.retain_buses(&mut spusb.buses);
 /// let flattened = spusb.flattened_devices();
 /// // node was on a hub so that will remain with it
@@ -2106,7 +2106,7 @@ pub type USBFilter = Filter;
 /// use cyme::profiler::*;
 ///
 /// # let mut spusb = read_json_dump(&"./tests/data/system_profiler_dump.json").unwrap();
-/// let filter = FilterGroup::from(Filter::new_with_vid_pid(0x1d50, 0x6018));
+/// let filter = DeviceFilter::from(Filter::new_with_vid_pid(0x1d50, 0x6018));
 /// filter.retain_buses(&mut spusb.buses);
 /// let flattened = spusb.flattened_devices();
 /// // node was on a hub so that will remain with it
@@ -2122,7 +2122,7 @@ pub type USBFilter = Filter;
 /// use cyme::profiler::*;
 ///
 /// # let mut spusb = read_json_dump(&"./tests/data/system_profiler_dump.json").unwrap();
-/// let filter = FilterGroup::from(Filter::new_with_bus_number(20, 6));
+/// let filter = DeviceFilter::from(Filter::new_with_bus_number(20, 6));
 /// let mut flattened = spusb.flattened_devices();
 /// filter.retain_flattened_devices_ref(&mut flattened);
 /// // now no hub
@@ -2136,7 +2136,7 @@ pub type USBFilter = Filter;
 /// use cyme::profiler::*;
 ///
 /// # let mut spusb = read_json_dump(&"./tests/data/cyme_libusb_merge_macos_tree.json").unwrap();
-/// let filter = FilterGroup::from(Filter::new_with_class(cyme::usb::BaseClass::CdcCommunications));
+/// let filter = DeviceFilter::from(Filter::new_with_class(cyme::usb::BaseClass::CdcCommunications));
 /// let mut flattened = spusb.flattened_devices();
 /// filter.retain_flattened_devices_ref(&mut flattened);
 /// // black magic probe has CDCCommunications serial
@@ -2150,7 +2150,7 @@ pub type USBFilter = Filter;
 /// use cyme::profiler::*;
 ///
 /// # let mut spusb = read_json_dump(&"./tests/data/system_profiler_dump.json").unwrap();
-/// let filter = FilterGroup {
+/// let filter = DeviceFilter {
 ///     no_exclude_root_hub: true,
 ///     ..Filter::new_with_name("Black Magic Probe".into(), false).into()
 /// };
@@ -2278,7 +2278,7 @@ impl Filter {
 
 /// Groups [`Filter`]s with OR semantics and an optional exclusion list
 ///
-/// Devices pass through a [`FilterGroup`] if:
+/// Devices pass through a [`DeviceFilter`] if:
 /// 1. They are not excluded by structural flags (`exclude_empty_hub`, `exclude_empty_bus`, root hub)
 /// 2. They match **any** filter in `filters` (OR), or `filters` is empty (matches all)
 /// 3. They do not match **any** filter in `exclude_filters`
@@ -2297,13 +2297,13 @@ impl Filter {
 /// Single filter — wraps one [`Filter`]:
 /// ```
 /// use cyme::profiler::*;
-/// let filter = FilterGroup::from(Filter::new_with_vid_pid(0x1d50, 0x6018));
+/// let filter = DeviceFilter::from(Filter::new_with_vid_pid(0x1d50, 0x6018));
 /// ```
 ///
 /// OR two VIDs — each `Filter` in the vec is an independent OR branch:
 /// ```
 /// use cyme::profiler::*;
-/// let filter = FilterGroup::from(vec![
+/// let filter = DeviceFilter::from(vec![
 ///     Filter::new_with_vid_pid(0x1234, 0x0001),
 ///     Filter::new_with_vid_pid(0x4321, 0x0002),
 /// ]);
@@ -2312,7 +2312,7 @@ impl Filter {
 /// With extra structural flags — struct update from a converted `Filter`:
 /// ```
 /// use cyme::profiler::*;
-/// let filter = FilterGroup {
+/// let filter = DeviceFilter {
 ///     no_exclude_root_hub: true,
 ///     ..Filter::new_with_name("Black Magic".into(), false).into()
 /// };
@@ -2321,7 +2321,7 @@ impl Filter {
 /// Exclusion — devices matching `exclude_filters` are always hidden:
 /// ```
 /// use cyme::profiler::*;
-/// let filter = FilterGroup {
+/// let filter = DeviceFilter {
 ///     filters: vec![Filter::new_with_class(cyme::usb::BaseClass::Hid)],
 ///     exclude_filters: vec![Filter::new_with_name("Keyboard".into(), false)],
 ///     ..Default::default()
@@ -2329,7 +2329,7 @@ impl Filter {
 /// ```
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case", default)]
-pub struct FilterGroup {
+pub struct DeviceFilter {
     /// Inclusion filters — device matches if it satisfies ANY of these (OR)
     pub filters: Vec<Filter>,
     /// Exclusion filters — device is excluded if it matches any of these
@@ -2342,7 +2342,7 @@ pub struct FilterGroup {
     pub no_exclude_root_hub: bool,
 }
 
-impl FilterGroup {
+impl DeviceFilter {
     /// Creates a new filter group with defaults
     pub fn new() -> Self {
         Default::default()
@@ -2470,18 +2470,18 @@ impl FilterGroup {
     }
 }
 
-impl From<Filter> for FilterGroup {
+impl From<Filter> for DeviceFilter {
     fn from(filter: Filter) -> Self {
-        FilterGroup {
+        DeviceFilter {
             filters: vec![filter],
             ..Default::default()
         }
     }
 }
 
-impl From<Vec<Filter>> for FilterGroup {
+impl From<Vec<Filter>> for DeviceFilter {
     fn from(filters: Vec<Filter>) -> Self {
-        FilterGroup {
+        DeviceFilter {
             filters,
             ..Default::default()
         }

--- a/src/profiler/types.rs
+++ b/src/profiler/types.rs
@@ -2153,7 +2153,7 @@ pub type USBFilter = Filter;
 ///
 /// # let mut spusb = read_json_dump(&"./tests/data/system_profiler_dump.json").unwrap();
 /// let filter = DeviceFilter {
-///     no_exclude_root_hub: true,
+///     include_root_hubs: true,
 ///     ..Filter::new_with_name("Black Magic Probe".into(), false).into()
 /// };
 /// let mut flattened = spusb.flattened_devices();
@@ -2316,7 +2316,7 @@ impl Filter {
 /// ```
 /// use cyme::profiler::*;
 /// let filter = DeviceFilter {
-///     no_exclude_root_hub: true,
+///     include_root_hubs: true,
 ///     ..Filter::new_with_name("Black Magic".into(), false).into()
 /// };
 /// ```
@@ -2341,8 +2341,8 @@ pub struct DeviceFilter {
     pub exclude_empty_bus: bool,
     /// Exclude empty hubs (those with no devices); when listing hides hubs regardless
     pub exclude_empty_hub: bool,
-    /// Do not exclude Linux root hub devices
-    pub no_exclude_root_hub: bool,
+    /// Include Linux root hub devices (excluded by default as they are pseudo buses)
+    pub include_root_hubs: bool,
 }
 
 impl DeviceFilter {
@@ -2356,7 +2356,7 @@ impl DeviceFilter {
         if self.exclude_empty_hub && device.is_hub() && !device.has_devices() {
             return false;
         }
-        if device.is_root_hub() && !self.no_exclude_root_hub {
+        if device.is_root_hub() && !self.include_root_hubs {
             return false;
         }
 
@@ -2377,7 +2377,7 @@ impl DeviceFilter {
     ///
     /// Used by profilers to decide whether to load extra device data
     pub fn is_potential_match(&self, device: &Device) -> bool {
-        if device.is_root_hub() && !self.no_exclude_root_hub {
+        if device.is_root_hub() && !self.include_root_hubs {
             return false;
         }
 

--- a/src/profiler/types.rs
+++ b/src/profiler/types.rs
@@ -14,7 +14,7 @@ use std::str::FromStr;
 
 use super::*;
 use crate::error::{Error, ErrorKind};
-use crate::types::NumericalUnit;
+use crate::types::{NumericalUnit, VidPid};
 use crate::usb::*;
 
 /// Root JSON returned from system_profiler and used as holder for all static USB bus data
@@ -1980,58 +1980,6 @@ impl<'a> IntoIterator for &'a mut Device {
 
     fn into_iter(self) -> std::vec::IntoIter<Self::Item> {
         self.flatten_mut().into_iter()
-    }
-}
-
-/// A vendor and product ID pair used in filter expressions, serialised as a hex string.
-///
-/// Accepts the formats `"VID:PID"`, `"VID:"`, `"VID"` (PID wildcard), or `":PID"` (VID wildcard).
-/// Both components are optional; an absent component matches any value.
-///
-/// ```
-/// use cyme::profiler::VidPid;
-/// let vp: VidPid = "1d50:6018".parse().unwrap();
-/// assert_eq!(vp, VidPid(Some(0x1d50), Some(0x6018)));
-/// let vp: VidPid = "05ac".parse().unwrap();
-/// assert_eq!(vp, VidPid(Some(0x05ac), None));
-/// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq, DeserializeFromStr, SerializeDisplay)]
-pub struct VidPid(pub Option<u16>, pub Option<u16>);
-
-impl std::fmt::Display for VidPid {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match (self.0, self.1) {
-            (Some(vid), Some(pid)) => write!(f, "{vid:04x}:{pid:04x}"),
-            (Some(vid), None) => write!(f, "{vid:04x}"),
-            (None, Some(pid)) => write!(f, ":{pid:04x}"),
-            (None, None) => write!(f, ":"),
-        }
-    }
-}
-
-impl std::str::FromStr for VidPid {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self> {
-        fn parse_hex(s: &str) -> Result<u16> {
-            u16::from_str_radix(s.trim().trim_start_matches("0x"), 16)
-                .map_err(|e| Error::new(ErrorKind::Parsing, &e.to_string()))
-        }
-        if let Some((vid_str, pid_str)) = s.split_once(':') {
-            let vid = if vid_str.trim().is_empty() {
-                None
-            } else {
-                Some(parse_hex(vid_str)?)
-            };
-            let pid = if pid_str.trim().is_empty() {
-                None
-            } else {
-                Some(parse_hex(pid_str)?)
-            };
-            Ok(VidPid(vid, pid))
-        } else {
-            Ok(VidPid(Some(parse_hex(s)?), None))
-        }
     }
 }
 

--- a/src/profiler/types.rs
+++ b/src/profiler/types.rs
@@ -2276,20 +2276,21 @@ impl Filter {
     }
 }
 
-/// Groups [`Filter`]s with OR semantics and an optional exclusion list
+/// The top-level USB device filter, combining inclusion [`Filter`]s and an optional exclusion list
+/// with some profiling structural flags.
 ///
 /// Devices pass through a [`DeviceFilter`] if:
 /// 1. They are not excluded by structural flags (`exclude_empty_hub`, `exclude_empty_bus`, root hub)
 /// 2. They match **any** filter in `filters` (OR), or `filters` is empty (matches all)
 /// 3. They do not match **any** filter in `exclude_filters`
 ///
-/// Filters within a group are always OR'd. AND is not needed: two `Filter`s that each constrain
-/// a different field (e.g. `vid` and `class`) can be expressed as a single `Filter` with both
-/// fields set — a device can never satisfy two different values of the same field simultaneously.
+/// Multiple `Filter`s are always OR'd — AND between separate filters is unnecessary because a
+/// single [`Filter`] already ANDs all its fields together, and a device can never satisfy two
+/// different values of the same field simultaneously.
 ///
 /// On the CLI, repeating the same flag (e.g. `--vidpid 0x1234 --vidpid 0x4321`) produces one
-/// `Filter` per value, all OR'd inside the group. Combining different flags (e.g. `--vidpid
-/// 0x1234 --filter-name Probe`) merges them into one `Filter` via cross-product, preserving AND
+/// `Filter` per value, all OR'd. Combining different flags (e.g. `--vidpid 0x1234
+/// --filter-name Probe`) merges them into a single `Filter` via cross-product, preserving AND
 /// semantics within that filter.
 ///
 /// # Construction
@@ -2343,12 +2344,12 @@ pub struct DeviceFilter {
 }
 
 impl DeviceFilter {
-    /// Creates a new filter group with defaults
+    /// Creates a new [`DeviceFilter`] with defaults
     pub fn new() -> Self {
         Default::default()
     }
 
-    /// Checks whether `device` passes through this filter group
+    /// Checks whether `device` passes through the [`DeviceFilter`]
     pub fn is_match(&self, device: &Device) -> bool {
         if self.exclude_empty_hub && device.is_hub() && !device.has_devices() {
             return false;
@@ -2370,7 +2371,7 @@ impl DeviceFilter {
             .any(|f| f.is_identity_match(device))
     }
 
-    /// Checks whether `device` could potentially match this filter group if extra data was loaded
+    /// Checks whether `device` could potentially match this filter if extra data was loaded
     ///
     /// Used by profilers to decide whether to load extra device data
     pub fn is_potential_match(&self, device: &Device) -> bool {
@@ -2393,7 +2394,7 @@ impl DeviceFilter {
             .any(|f| f.class.is_none() && f.is_identity_match(device))
     }
 
-    /// Checks whether `bus` passes through this filter group
+    /// Checks whether `bus` passes through this filter
     pub fn is_bus_match(&self, bus: &Bus) -> bool {
         if self.exclude_empty_bus && bus.is_empty() {
             return false;
@@ -2409,7 +2410,7 @@ impl DeviceFilter {
             .any(|f| f.bus.is_none() || bus_no == f.bus || bus_no.is_none())
     }
 
-    /// Recursively looks down tree for any `device` matching this filter group
+    /// Recursively looks down tree for any `device` matching this filter
     pub fn exists_in_tree(&self, device: &Device) -> bool {
         if self.is_match(device) {
             return true;
@@ -2420,49 +2421,57 @@ impl DeviceFilter {
         }
     }
 
-    /// Recursively retain only `Bus` in `buses` with `Device` matching filter group
+    /// Recursively retain only `Bus` in `buses` with `Device` matching filter
     pub fn retain_buses(&self, buses: &mut Vec<Bus>) {
+        // filter any empty or number matches
         buses.retain(|b| self.is_bus_match(b));
+
         for bus in buses.iter_mut() {
             bus.devices.iter_mut().for_each(|d| self.retain_devices(d));
         }
+
+        // check bus match again in case empty after device filter
         buses.retain(|b| self.is_bus_match(b));
     }
 
-    /// Recursively hide `Bus` in `buses` not matching filter group
+    /// Recursively hide `Bus` in `buses` not matching filter
     pub fn hide_buses(&self, buses: &mut [Bus]) {
         buses
             .iter_mut()
             .for_each(|b| b.internal.hidden = !self.is_bus_match(b));
+
         for bus in buses.iter_mut() {
             bus.devices.iter_mut().for_each(|d| self.hide_devices(d));
         }
+
         buses
             .iter_mut()
             .for_each(|b| b.internal.hidden = !self.is_bus_match(b));
     }
 
-    /// Recursively retain only `Device` in `devices` matching filter group
+    /// Recursively retain only `Device` in `devices` matching filter
     ///
     /// Note that non-matching parents will still be retained if they have a matching `Device` within their branches
     pub fn retain_devices(&self, devices: &mut Vec<Device>) {
         devices.retain(|d| self.exists_in_tree(d));
+
         for d in devices {
             d.devices.iter_mut().for_each(|d| self.retain_devices(d));
         }
     }
 
-    /// Recursively hide `Device` in `devices` not matching filter group
+    /// Recursively hide `Device` in `devices` not matching filter
     pub fn hide_devices(&self, devices: &mut [Device]) {
         devices
             .iter_mut()
             .for_each(|d| d.internal.hidden = !self.exists_in_tree(d));
+
         for d in devices {
             d.devices.iter_mut().for_each(|d| self.hide_devices(d));
         }
     }
 
-    /// Retains only `&Device` in `devices` which match filter group
+    /// Retains only `&Device` in `devices` which match filter
     ///
     /// Does not check down tree so should be used with flattened devices only
     pub fn retain_flattened_devices_ref(&self, devices: &mut Vec<&Device>) {

--- a/src/profiler/types.rs
+++ b/src/profiler/types.rs
@@ -1986,6 +1986,7 @@ impl<'a> IntoIterator for &'a mut Device {
 /// Used to filter devices within buses
 ///
 /// The tree to a [`Device`] is kept even if parent branches are not matches. To avoid this, one must flatten the devices first.
+#[skip_serializing_none]
 #[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(default)]
 pub struct Filter {
@@ -2004,6 +2005,7 @@ pub struct Filter {
     /// retain only device of BaseClass class
     pub class: Option<BaseClass>,
     /// Case sensitive matching for strings. False will be unless capital letter in query
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub case_sensitive: bool,
 }
 

--- a/src/profiler/types.rs
+++ b/src/profiler/types.rs
@@ -2091,10 +2091,7 @@ pub type USBFilter = Filter;
 /// use cyme::profiler::*;
 ///
 /// # let mut spusb = read_json_dump(&"./tests/data/system_profiler_dump.json").unwrap();
-/// let filter = FilterGroup::from(Filter {
-///     name: Some(String::from("Black Magic Probe")),
-///     ..Default::default()
-/// });
+/// let filter = FilterGroup::from(Filter::new_with_name("Black Magic Probe".into(), false));
 /// filter.retain_buses(&mut spusb.buses);
 /// let flattened = spusb.flattened_devices();
 /// // node was on a hub so that will remain with it
@@ -2109,11 +2106,7 @@ pub type USBFilter = Filter;
 /// use cyme::profiler::*;
 ///
 /// # let mut spusb = read_json_dump(&"./tests/data/system_profiler_dump.json").unwrap();
-/// let filter = FilterGroup::from(Filter {
-///     vid: Some(0x1d50),
-///     pid: Some(0x6018),
-///     ..Default::default()
-/// });
+/// let filter = FilterGroup::from(Filter::new_with_vid_pid(0x1d50, 0x6018));
 /// filter.retain_buses(&mut spusb.buses);
 /// let flattened = spusb.flattened_devices();
 /// // node was on a hub so that will remain with it
@@ -2129,11 +2122,7 @@ pub type USBFilter = Filter;
 /// use cyme::profiler::*;
 ///
 /// # let mut spusb = read_json_dump(&"./tests/data/system_profiler_dump.json").unwrap();
-/// let filter = FilterGroup::from(Filter {
-///     number: Some(6),
-///     bus: Some(20),
-///     ..Default::default()
-/// });
+/// let filter = FilterGroup::from(Filter::new_with_bus_number(20, 6));
 /// let mut flattened = spusb.flattened_devices();
 /// filter.retain_flattened_devices_ref(&mut flattened);
 /// // now no hub
@@ -2147,10 +2136,7 @@ pub type USBFilter = Filter;
 /// use cyme::profiler::*;
 ///
 /// # let mut spusb = read_json_dump(&"./tests/data/cyme_libusb_merge_macos_tree.json").unwrap();
-/// let filter = FilterGroup::from(Filter {
-///     class: Some(cyme::usb::BaseClass::CdcCommunications),
-///     ..Default::default()
-/// });
+/// let filter = FilterGroup::from(Filter::new_with_class(cyme::usb::BaseClass::CdcCommunications));
 /// let mut flattened = spusb.flattened_devices();
 /// filter.retain_flattened_devices_ref(&mut flattened);
 /// // black magic probe has CDCCommunications serial

--- a/src/profiler/types.rs
+++ b/src/profiler/types.rs
@@ -1986,7 +1986,8 @@ impl<'a> IntoIterator for &'a mut Device {
 /// Used to filter devices within buses
 ///
 /// The tree to a [`Device`] is kept even if parent branches are not matches. To avoid this, one must flatten the devices first.
-#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+#[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(default)]
 pub struct Filter {
     /// Retain only devices with vendor id matching this
     pub vid: Option<u16>,
@@ -2002,12 +2003,6 @@ pub struct Filter {
     pub serial: Option<String>,
     /// retain only device of BaseClass class
     pub class: Option<BaseClass>,
-    /// Exclude empty buses in the tree
-    pub exclude_empty_bus: bool,
-    /// Exclude empty hubs in the tree
-    pub exclude_empty_hub: bool,
-    /// Don't exclude Linux root_hub devices - this is inverse because they are pseudo [`Bus`]'s in the tree
-    pub no_exclude_root_hub: bool,
     /// Case sensitive matching for strings. False will be unless capital letter in query
     pub case_sensitive: bool,
 }
@@ -2058,7 +2053,7 @@ impl ProfileDepth {
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct ProfilerOptions {
     /// Filter to apply during profiling
-    pub filter: Option<Filter>,
+    pub filter: Option<FilterGroup>,
     /// How much data to collect for each device
     pub depth: ProfileDepth,
     /// Whether we are building a tree (true) or just a flat list (false)
@@ -2096,10 +2091,10 @@ pub type USBFilter = Filter;
 /// use cyme::profiler::*;
 ///
 /// # let mut spusb = read_json_dump(&"./tests/data/system_profiler_dump.json").unwrap();
-/// let filter = Filter {
+/// let filter = FilterGroup::from(Filter {
 ///     name: Some(String::from("Black Magic Probe")),
 ///     ..Default::default()
-/// };
+/// });
 /// filter.retain_buses(&mut spusb.buses);
 /// let flattened = spusb.flattened_devices();
 /// // node was on a hub so that will remain with it
@@ -2114,11 +2109,11 @@ pub type USBFilter = Filter;
 /// use cyme::profiler::*;
 ///
 /// # let mut spusb = read_json_dump(&"./tests/data/system_profiler_dump.json").unwrap();
-/// let filter = Filter {
+/// let filter = FilterGroup::from(Filter {
 ///     vid: Some(0x1d50),
 ///     pid: Some(0x6018),
 ///     ..Default::default()
-/// };
+/// });
 /// filter.retain_buses(&mut spusb.buses);
 /// let flattened = spusb.flattened_devices();
 /// // node was on a hub so that will remain with it
@@ -2134,11 +2129,11 @@ pub type USBFilter = Filter;
 /// use cyme::profiler::*;
 ///
 /// # let mut spusb = read_json_dump(&"./tests/data/system_profiler_dump.json").unwrap();
-/// let filter = Filter {
+/// let filter = FilterGroup::from(Filter {
 ///     number: Some(6),
 ///     bus: Some(20),
 ///     ..Default::default()
-/// };
+/// });
 /// let mut flattened = spusb.flattened_devices();
 /// filter.retain_flattened_devices_ref(&mut flattened);
 /// // now no hub
@@ -2152,10 +2147,10 @@ pub type USBFilter = Filter;
 /// use cyme::profiler::*;
 ///
 /// # let mut spusb = read_json_dump(&"./tests/data/cyme_libusb_merge_macos_tree.json").unwrap();
-/// let filter = Filter {
+/// let filter = FilterGroup::from(Filter {
 ///     class: Some(cyme::usb::BaseClass::CdcCommunications),
 ///     ..Default::default()
-/// };
+/// });
 /// let mut flattened = spusb.flattened_devices();
 /// filter.retain_flattened_devices_ref(&mut flattened);
 /// // black magic probe has CDCCommunications serial
@@ -2163,10 +2158,68 @@ pub type USBFilter = Filter;
 /// assert_eq!(device.unwrap().name, "Black Magic Probe  v1.8.2");
 /// ```
 ///
+/// Combine filters with a single struct update when extra flags are needed
+///
+/// ```
+/// use cyme::profiler::*;
+///
+/// # let mut spusb = read_json_dump(&"./tests/data/system_profiler_dump.json").unwrap();
+/// let filter = FilterGroup {
+///     no_exclude_root_hub: true,
+///     ..Filter::new_with_name("Black Magic Probe".into(), false).into()
+/// };
+/// let mut flattened = spusb.flattened_devices();
+/// filter.retain_flattened_devices_ref(&mut flattened);
+/// assert!(!flattened.is_empty());
+/// ```
+///
 impl Filter {
     /// Creates a new filter with defaults
     pub fn new() -> Self {
         Default::default()
+    }
+
+    /// Creates a new filter with name filter
+    pub fn new_with_name(name: String, case_sensitive: bool) -> Self {
+        Self {
+            name: Some(name),
+            case_sensitive,
+            ..Default::default()
+        }
+    }
+
+    /// Creates a new filter with vid and pid filter
+    pub fn new_with_vid_pid(vid: u16, pid: u16) -> Self {
+        Self {
+            vid: Some(vid),
+            pid: Some(pid),
+            ..Default::default()
+        }
+    }
+
+    /// Creates a new filter with bus and number filter
+    pub fn new_with_bus_number(bus: u8, number: u8) -> Self {
+        Self {
+            bus: Some(bus),
+            number: Some(number),
+            ..Default::default()
+        }
+    }
+
+    /// Creates a new filter with class filter
+    pub fn new_with_class(class: BaseClass) -> Self {
+        Self {
+            class: Some(class),
+            ..Default::default()
+        }
+    }
+
+    /// Creates a new filter with serial filter
+    pub fn new_with_serial(serial: String) -> Self {
+        Self {
+            serial: Some(serial),
+            ..Default::default()
+        }
     }
 
     fn string_match(&self, pattern: &Option<String>, query: Option<&String>) -> bool {
@@ -2190,8 +2243,6 @@ impl Filter {
     /// Checks whether `device` passes through filter
     pub fn is_match(&self, device: &Device) -> bool {
         self.is_identity_match(device)
-            && !(self.exclude_empty_hub && device.is_hub() && !device.has_devices())
-            && (!device.is_root_hub() || self.no_exclude_root_hub)
     }
 
     /// Checks whether `device` matches the identity criteria of the filter (VID, PID, Name, Serial, Class, etc.)
@@ -2221,13 +2272,6 @@ impl Filter {
             && self.class.as_ref().is_none_or(|fc| {
                 device.class.as_ref() == Some(fc) || device.extra.is_none()
             })
-            && (!device.is_root_hub() || self.no_exclude_root_hub)
-    }
-
-    /// Checks whether `bus` passes through filter
-    pub fn is_bus_match(&self, bus: &Bus) -> bool {
-        (bus.usb_bus_number == self.bus || self.bus.is_none() || bus.usb_bus_number.is_none())
-            && !(self.exclude_empty_bus && bus.is_empty())
     }
 
     /// Recursively looks down tree for any `device` matching filter
@@ -2244,62 +2288,217 @@ impl Filter {
             None => false,
         }
     }
+}
 
-    /// Recursively retain only `Bus` in `buses` with `Device` matching filter
+/// Groups [`Filter`]s with OR semantics and an optional exclusion list
+///
+/// Devices pass through a [`FilterGroup`] if:
+/// 1. They are not excluded by structural flags (`exclude_empty_hub`, `exclude_empty_bus`, root hub)
+/// 2. They match **any** filter in `filters` (OR), or `filters` is empty (matches all)
+/// 3. They do not match **any** filter in `exclude_filters`
+///
+/// Filters within a group are always OR'd. AND is not needed: two `Filter`s that each constrain
+/// a different field (e.g. `vid` and `class`) can be expressed as a single `Filter` with both
+/// fields set — a device can never satisfy two different values of the same field simultaneously.
+///
+/// On the CLI, repeating the same flag (e.g. `--vidpid 0x1234 --vidpid 0x4321`) produces one
+/// `Filter` per value, all OR'd inside the group. Combining different flags (e.g. `--vidpid
+/// 0x1234 --filter-name Probe`) merges them into one `Filter` via cross-product, preserving AND
+/// semantics within that filter.
+///
+/// # Construction
+///
+/// Single filter — wraps one [`Filter`]:
+/// ```
+/// use cyme::profiler::*;
+/// let filter = FilterGroup::from(Filter::new_with_vid_pid(0x1d50, 0x6018));
+/// ```
+///
+/// OR two VIDs — each `Filter` in the vec is an independent OR branch:
+/// ```
+/// use cyme::profiler::*;
+/// let filter = FilterGroup::from(vec![
+///     Filter::new_with_vid_pid(0x1234, 0x0001),
+///     Filter::new_with_vid_pid(0x4321, 0x0002),
+/// ]);
+/// ```
+///
+/// With extra structural flags — struct update from a converted `Filter`:
+/// ```
+/// use cyme::profiler::*;
+/// let filter = FilterGroup {
+///     no_exclude_root_hub: true,
+///     ..Filter::new_with_name("Black Magic".into(), false).into()
+/// };
+/// ```
+///
+/// Exclusion — devices matching `exclude_filters` are always hidden:
+/// ```
+/// use cyme::profiler::*;
+/// let filter = FilterGroup {
+///     filters: vec![Filter::new_with_class(cyme::usb::BaseClass::Hid)],
+///     exclude_filters: vec![Filter::new_with_name("Keyboard".into(), false)],
+///     ..Default::default()
+/// };
+/// ```
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case", default)]
+pub struct FilterGroup {
+    /// Inclusion filters — device matches if it satisfies ANY of these (OR)
+    pub filters: Vec<Filter>,
+    /// Exclusion filters — device is excluded if it matches any of these
+    pub exclude_filters: Vec<Filter>,
+    /// Exclude empty buses (those with no devices)
+    pub exclude_empty_bus: bool,
+    /// Exclude empty hubs (those with no devices); when listing hides hubs regardless
+    pub exclude_empty_hub: bool,
+    /// Do not exclude Linux root hub devices
+    pub no_exclude_root_hub: bool,
+}
+
+impl FilterGroup {
+    /// Creates a new filter group with defaults
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Checks whether `device` passes through this filter group
+    pub fn is_match(&self, device: &Device) -> bool {
+        if self.exclude_empty_hub && device.is_hub() && !device.has_devices() {
+            return false;
+        }
+        if device.is_root_hub() && !self.no_exclude_root_hub {
+            return false;
+        }
+
+        let included =
+            self.filters.is_empty() || self.filters.iter().any(|f| f.is_identity_match(device));
+
+        if !included {
+            return false;
+        }
+
+        !self
+            .exclude_filters
+            .iter()
+            .any(|f| f.is_identity_match(device))
+    }
+
+    /// Checks whether `device` could potentially match this filter group if extra data was loaded
+    ///
+    /// Used by profilers to decide whether to load extra device data
+    pub fn is_potential_match(&self, device: &Device) -> bool {
+        if device.is_root_hub() && !self.no_exclude_root_hub {
+            return false;
+        }
+
+        let potentially_included =
+            self.filters.is_empty() || self.filters.iter().any(|f| f.is_potential_match(device));
+
+        if !potentially_included {
+            return false;
+        }
+
+        // Only definitively exclude if the exclusion filter has no class criteria
+        // (class requires extra data to evaluate interfaces)
+        !self
+            .exclude_filters
+            .iter()
+            .any(|f| f.class.is_none() && f.is_identity_match(device))
+    }
+
+    /// Checks whether `bus` passes through this filter group
+    pub fn is_bus_match(&self, bus: &Bus) -> bool {
+        if self.exclude_empty_bus && bus.is_empty() {
+            return false;
+        }
+
+        if self.filters.is_empty() {
+            return true;
+        }
+
+        let bus_no = bus.usb_bus_number;
+        self.filters
+            .iter()
+            .any(|f| f.bus.is_none() || bus_no == f.bus || bus_no.is_none())
+    }
+
+    /// Recursively looks down tree for any `device` matching this filter group
+    pub fn exists_in_tree(&self, device: &Device) -> bool {
+        if self.is_match(device) {
+            return true;
+        }
+        match &device.devices {
+            Some(devs) => devs.iter().any(|d| self.exists_in_tree(d)),
+            None => false,
+        }
+    }
+
+    /// Recursively retain only `Bus` in `buses` with `Device` matching filter group
     pub fn retain_buses(&self, buses: &mut Vec<Bus>) {
-        // filter any empty or number matches
         buses.retain(|b| self.is_bus_match(b));
-
         for bus in buses.iter_mut() {
             bus.devices.iter_mut().for_each(|d| self.retain_devices(d));
         }
-
-        // check bus match again in case empty after device filter
         buses.retain(|b| self.is_bus_match(b));
     }
 
-    /// Recursively hide `Bus` in `buses` with `Device` matching filter
+    /// Recursively hide `Bus` in `buses` not matching filter group
     pub fn hide_buses(&self, buses: &mut [Bus]) {
         buses
             .iter_mut()
             .for_each(|b| b.internal.hidden = !self.is_bus_match(b));
-
         for bus in buses.iter_mut() {
             bus.devices.iter_mut().for_each(|d| self.hide_devices(d));
         }
-
         buses
             .iter_mut()
             .for_each(|b| b.internal.hidden = !self.is_bus_match(b));
     }
 
-    /// Recursively retain only `Device` in `devices` matching filter
+    /// Recursively retain only `Device` in `devices` matching filter group
     ///
     /// Note that non-matching parents will still be retained if they have a matching `Device` within their branches
     pub fn retain_devices(&self, devices: &mut Vec<Device>) {
         devices.retain(|d| self.exists_in_tree(d));
-
         for d in devices {
             d.devices.iter_mut().for_each(|d| self.retain_devices(d));
         }
     }
 
-    /// Recursively retain only `Device` in `devices` matching filter
+    /// Recursively hide `Device` in `devices` not matching filter group
     pub fn hide_devices(&self, devices: &mut [Device]) {
         devices
             .iter_mut()
             .for_each(|d| d.internal.hidden = !self.exists_in_tree(d));
-
         for d in devices {
             d.devices.iter_mut().for_each(|d| self.hide_devices(d));
         }
     }
 
-    /// Retains only `&Device` in `devices` which match filter
+    /// Retains only `&Device` in `devices` which match filter group
     ///
-    /// Does not check down tree so should be used to flattened devices only (`get_all_devices`). Will remove hubs if `hide_hubs` since when flattened they will have no devices
+    /// Does not check down tree so should be used with flattened devices only
     pub fn retain_flattened_devices_ref(&self, devices: &mut Vec<&Device>) {
         devices.retain(|d| self.is_match(d))
+    }
+}
+
+impl From<Filter> for FilterGroup {
+    fn from(filter: Filter) -> Self {
+        FilterGroup {
+            filters: vec![filter],
+            ..Default::default()
+        }
+    }
+}
+
+impl From<Vec<Filter>> for FilterGroup {
+    fn from(filters: Vec<Filter>) -> Self {
+        FilterGroup {
+            filters,
+            ..Default::default()
+        }
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,8 +4,86 @@ use std::str::FromStr;
 
 use serde::de::{self, MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize};
+use serde_with::{DeserializeFromStr, SerializeDisplay};
 
 use crate::error::{self, Error, ErrorKind};
+
+/// A vendor and product ID pair used in filter expressions, serialised as a hex string.
+///
+/// Accepts the formats `"VID:PID"`, `"VID:"`, `"VID"` (PID wildcard), or `":PID"` (VID wildcard).
+/// Both components are optional; an absent component matches any value.
+///
+/// ```
+/// use cyme::types::VidPid;
+/// let vp: VidPid = "1d50:6018".parse().unwrap();
+/// assert_eq!(vp, VidPid(Some(0x1d50), Some(0x6018)));
+/// let vp: VidPid = "05ac".parse().unwrap();
+/// assert_eq!(vp, VidPid(Some(0x05ac), None));
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, DeserializeFromStr, SerializeDisplay)]
+pub struct VidPid(pub Option<u16>, pub Option<u16>);
+
+impl fmt::Display for VidPid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match (self.0, self.1) {
+            (Some(vid), Some(pid)) => write!(f, "{vid:04x}:{pid:04x}"),
+            (Some(vid), None) => write!(f, "{vid:04x}"),
+            (None, Some(pid)) => write!(f, ":{pid:04x}"),
+            (None, None) => write!(f, ":"),
+        }
+    }
+}
+
+impl FromStr for VidPid {
+    type Err = Error;
+
+    fn from_str(s: &str) -> error::Result<Self> {
+        fn parse_hex(s: &str) -> error::Result<u16> {
+            u16::from_str_radix(s.trim().trim_start_matches("0x"), 16)
+                .map_err(|e| Error::new(ErrorKind::Parsing, &e.to_string()))
+        }
+        if let Some((vid_str, pid_str)) = s.split_once(':') {
+            let vid = if vid_str.trim().is_empty() {
+                None
+            } else {
+                Some(parse_hex(vid_str)?)
+            };
+            let pid = if pid_str.trim().is_empty() {
+                None
+            } else {
+                Some(parse_hex(pid_str)?)
+            };
+            Ok(VidPid(vid, pid))
+        } else {
+            Ok(VidPid(Some(parse_hex(s)?), None))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_vidpid_parse() {
+        assert_eq!(
+            "000A:0x000b".parse::<VidPid>().unwrap(),
+            VidPid(Some(0x0A), Some(0x0b))
+        );
+        assert_eq!(
+            "000A:1".parse::<VidPid>().unwrap(),
+            VidPid(Some(0x0A), Some(1))
+        );
+        assert_eq!("000A:".parse::<VidPid>().unwrap(), VidPid(Some(0x0A), None));
+        assert_eq!(
+            "0x000A".parse::<VidPid>().unwrap(),
+            VidPid(Some(0x0A), None)
+        );
+        assert!("dfg:sdfd".parse::<VidPid>().is_err());
+        // values that would silently truncate with u32-as-u16 should now error
+        assert!("1ffff".parse::<VidPid>().is_err());
+    }
+}
 
 /// A numerical `value` converted from a String, which includes a `unit` and `description`
 ///

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -157,10 +157,7 @@ struct Display {
 }
 
 fn set_filter(field: &FilterField, value: Option<String>, filter: &mut FilterGroup) -> Result<()> {
-    if filter.filters.is_empty() {
-        filter.filters.push(Filter::default());
-    }
-    let f = &mut filter.filters[0];
+    let mut f = filter.filters.first().cloned().unwrap_or_default();
     match field {
         FilterField::Name => f.name = value,
         FilterField::Serial => f.serial = value,
@@ -185,15 +182,7 @@ fn set_filter(field: &FilterField, value: Option<String>, filter: &mut FilterGro
             None => f.class = None,
         },
     };
-    // If filter is now empty, clear the filters vec
-    if f.vid.is_none()
-        && f.pid.is_none()
-        && f.name.is_none()
-        && f.serial.is_none()
-        && f.class.is_none()
-    {
-        filter.filters.clear();
-    }
+    filter.filters = if f == Filter::default() { vec![] } else { vec![f] };
     Ok(())
 }
 

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -182,7 +182,11 @@ fn set_filter(field: &FilterField, value: Option<String>, filter: &mut FilterGro
             None => f.class = None,
         },
     };
-    filter.filters = if f == Filter::default() { vec![] } else { vec![f] };
+    filter.filters = if f == Filter::default() {
+        vec![]
+    } else {
+        vec![f]
+    };
     Ok(())
 }
 

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -22,7 +22,7 @@ use super::parse_vidpid;
 use cyme::config::Config;
 use cyme::display::*;
 use cyme::error::{Error, ErrorKind, Result};
-use cyme::profiler::{watch::SystemProfileStreamBuilder, Filter, DeviceFilter, SystemProfile};
+use cyme::profiler::{watch::SystemProfileStreamBuilder, DeviceFilter, Filter, SystemProfile};
 
 #[derive(Debug, Clone)]
 #[allow(dead_code)]

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -22,7 +22,7 @@ use super::parse_vidpid;
 use cyme::config::Config;
 use cyme::display::*;
 use cyme::error::{Error, ErrorKind, Result};
-use cyme::profiler::{watch::SystemProfileStreamBuilder, Filter, SystemProfile};
+use cyme::profiler::{watch::SystemProfileStreamBuilder, Filter, FilterGroup, SystemProfile};
 
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
@@ -134,7 +134,7 @@ struct Display {
     buffer: Vec<u8>,
     spusb: Arc<Mutex<SystemProfile>>,
     print_settings: Arc<Mutex<PrintSettings>>,
-    filter: Filter,
+    filter: FilterGroup,
     state: Arc<Mutex<State>>,
     /// Size of current window
     terminal_size: (u16, u16),
@@ -156,32 +156,44 @@ struct Display {
     selected_item: Option<LineItem>,
 }
 
-fn set_filter(field: &FilterField, value: Option<String>, filter: &mut Filter) -> Result<()> {
+fn set_filter(field: &FilterField, value: Option<String>, filter: &mut FilterGroup) -> Result<()> {
+    if filter.filters.is_empty() {
+        filter.filters.push(Filter::default());
+    }
+    let f = &mut filter.filters[0];
     match field {
-        FilterField::Name => filter.name = value,
-        FilterField::Serial => filter.serial = value,
+        FilterField::Name => f.name = value,
+        FilterField::Serial => f.serial = value,
         FilterField::VidPid => match value {
             Some(s) => {
                 let (vid, pid) = parse_vidpid(&s)?;
-                filter.vid = vid;
-                filter.pid = pid;
+                f.vid = vid;
+                f.pid = pid;
             }
             None => {
-                filter.vid = None;
-                filter.pid = None;
+                f.vid = None;
+                f.pid = None;
             }
         },
         FilterField::Class => match value {
             Some(s) => {
-                filter.class = Some(
+                f.class = Some(
                     cyme::usb::BaseClass::from_str(&s, true)
                         .map_err(|e| Error::new(ErrorKind::Parsing, &e.to_string()))?,
                 );
             }
-            None => filter.class = None,
+            None => f.class = None,
         },
     };
-
+    // If filter is now empty, clear the filters vec
+    if f.vid.is_none()
+        && f.pid.is_none()
+        && f.name.is_none()
+        && f.serial.is_none()
+        && f.class.is_none()
+    {
+        filter.filters.clear();
+    }
     Ok(())
 }
 
@@ -192,7 +204,7 @@ fn strip_ansi_codes(input: &str) -> String {
 
 fn print_json(
     spusb: &mut SystemProfile,
-    filter: Option<&Filter>,
+    filter: Option<&FilterGroup>,
     print_settings: &PrintSettings,
 ) -> Result<()> {
     cyme::display::prepare(spusb, filter, print_settings);
@@ -203,7 +215,7 @@ fn print_json(
 
 pub fn watch_usb_devices_json(
     spusb: SystemProfile,
-    filter: Option<Filter>,
+    filter: Option<FilterGroup>,
     print_settings: PrintSettings,
 ) -> Result<()> {
     // pass spusb to stream builder, will get Arc<Mutex<SystemProfile>> back below
@@ -249,7 +261,7 @@ pub fn watch_usb_devices_json(
 
 pub fn watch_usb_devices(
     spusb: SystemProfile,
-    filter: Option<Filter>,
+    filter: Option<FilterGroup>,
     mut print_settings: PrintSettings,
     mut config: Config,
 ) -> Result<()> {
@@ -452,14 +464,30 @@ pub fn watch_usb_devices(
 
             Ok(WatchEvent::EditFilter(field)) => {
                 let original = match field {
-                    FilterField::Name => display.filter.name.clone(),
-                    FilterField::Serial => display.filter.serial.clone(),
-                    FilterField::VidPid => match (display.filter.vid, display.filter.pid) {
-                        (Some(vid), Some(pid)) => Some(format!("{vid:04x}:{pid:04x}")),
-                        (Some(vid), None) => Some(format!("{vid:04x}")),
-                        _ => None,
-                    },
-                    FilterField::Class => display.filter.class.map(|c| c.to_string()),
+                    FilterField::Name => {
+                        display.filter.filters.first().and_then(|f| f.name.clone())
+                    }
+                    FilterField::Serial => display
+                        .filter
+                        .filters
+                        .first()
+                        .and_then(|f| f.serial.clone()),
+                    FilterField::VidPid => {
+                        display
+                            .filter
+                            .filters
+                            .first()
+                            .and_then(|f| match (f.vid, f.pid) {
+                                (Some(vid), Some(pid)) => Some(format!("{vid:04x}:{pid:04x}")),
+                                (Some(vid), None) => Some(format!("{vid:04x}")),
+                                _ => None,
+                            })
+                    }
+                    FilterField::Class => display
+                        .filter
+                        .filters
+                        .first()
+                        .and_then(|f| f.class.map(|c| c.to_string())),
                 };
                 *display.state.lock().unwrap() = State::EditingFilter {
                     field,
@@ -1135,15 +1163,19 @@ impl Display {
             _ => {
                 format!(
                     " FILTERS Name={:?} Serial={:?} VID:PID={}:{} Class={:?}",
-                    self.filter.name,
-                    self.filter.serial,
+                    self.filter.filters.first().and_then(|f| f.name.as_ref()),
+                    self.filter.filters.first().and_then(|f| f.serial.as_ref()),
                     self.filter
-                        .vid
+                        .filters
+                        .first()
+                        .and_then(|f| f.vid)
                         .map_or("".to_string(), |v| format!("{v:04x}")),
                     self.filter
-                        .pid
+                        .filters
+                        .first()
+                        .and_then(|f| f.pid)
                         .map_or("".to_string(), |p| format!("{p:04x}")),
-                    self.filter.class
+                    self.filter.filters.first().and_then(|f| f.class),
                 )
             }
         };

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -18,11 +18,11 @@ use std::io::Write;
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
 
-use super::parse_vidpid;
 use cyme::config::Config;
 use cyme::display::*;
 use cyme::error::{Error, ErrorKind, Result};
 use cyme::profiler::{watch::SystemProfileStreamBuilder, DeviceFilter, Filter, SystemProfile};
+use cyme::types::VidPid;
 
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
@@ -163,9 +163,9 @@ fn set_filter(field: &FilterField, value: Option<String>, filter: &mut DeviceFil
         FilterField::Serial => f.serial = value,
         FilterField::VidPid => match value {
             Some(s) => {
-                let (vid, pid) = parse_vidpid(&s)?;
-                f.vid = vid;
-                f.pid = pid;
+                let vp = s.parse::<VidPid>()?;
+                f.vid = vp.0;
+                f.pid = vp.1;
             }
             None => {
                 f.vid = None;

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -22,7 +22,7 @@ use super::parse_vidpid;
 use cyme::config::Config;
 use cyme::display::*;
 use cyme::error::{Error, ErrorKind, Result};
-use cyme::profiler::{watch::SystemProfileStreamBuilder, Filter, FilterGroup, SystemProfile};
+use cyme::profiler::{watch::SystemProfileStreamBuilder, Filter, DeviceFilter, SystemProfile};
 
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
@@ -134,7 +134,7 @@ struct Display {
     buffer: Vec<u8>,
     spusb: Arc<Mutex<SystemProfile>>,
     print_settings: Arc<Mutex<PrintSettings>>,
-    filter: FilterGroup,
+    filter: DeviceFilter,
     state: Arc<Mutex<State>>,
     /// Size of current window
     terminal_size: (u16, u16),
@@ -156,7 +156,7 @@ struct Display {
     selected_item: Option<LineItem>,
 }
 
-fn set_filter(field: &FilterField, value: Option<String>, filter: &mut FilterGroup) -> Result<()> {
+fn set_filter(field: &FilterField, value: Option<String>, filter: &mut DeviceFilter) -> Result<()> {
     let mut f = filter.filters.first().cloned().unwrap_or_default();
     match field {
         FilterField::Name => f.name = value,
@@ -197,7 +197,7 @@ fn strip_ansi_codes(input: &str) -> String {
 
 fn print_json(
     spusb: &mut SystemProfile,
-    filter: Option<&FilterGroup>,
+    filter: Option<&DeviceFilter>,
     print_settings: &PrintSettings,
 ) -> Result<()> {
     cyme::display::prepare(spusb, filter, print_settings);
@@ -208,7 +208,7 @@ fn print_json(
 
 pub fn watch_usb_devices_json(
     spusb: SystemProfile,
-    filter: Option<FilterGroup>,
+    filter: Option<DeviceFilter>,
     print_settings: PrintSettings,
 ) -> Result<()> {
     // pass spusb to stream builder, will get Arc<Mutex<SystemProfile>> back below
@@ -254,7 +254,7 @@ pub fn watch_usb_devices_json(
 
 pub fn watch_usb_devices(
     spusb: SystemProfile,
-    filter: Option<FilterGroup>,
+    filter: Option<DeviceFilter>,
     mut print_settings: PrintSettings,
     mut config: Config,
 ) -> Result<()> {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -44,7 +44,7 @@ fn test_list_filtering() {
 
     let mut comp_sp = common::sp_data_from_libusb_linux();
     let filter = cyme::profiler::DeviceFilter {
-        no_exclude_root_hub: true,
+        include_root_hubs: true,
         ..cyme::profiler::Filter {
             name: Some("Black Magic".into()),
             ..Default::default()
@@ -91,7 +91,7 @@ fn test_list_filtering() {
 
     let mut comp_sp = common::sp_data_from_libusb_linux();
     let mut filter = cyme::profiler::DeviceFilter {
-        no_exclude_root_hub: true,
+        include_root_hubs: true,
         ..cyme::profiler::Filter {
             bus: Some(2),
             ..Default::default()
@@ -137,7 +137,7 @@ fn test_list_filtering() {
     {
         let mut comp_sp = common::sp_data_from_libusb_linux();
         let filter = cyme::profiler::DeviceFilter {
-            no_exclude_root_hub: true,
+            include_root_hubs: true,
             ..cyme::profiler::DeviceFilter::from(vec![
                 cyme::profiler::Filter::new_with_vid_pid(0x1d50, 0x6018),
                 cyme::profiler::Filter::new_with_vid_pid(0x1366, 0x1050),
@@ -160,7 +160,7 @@ fn test_list_filtering() {
     {
         let mut comp_sp = common::sp_data_from_libusb_linux();
         let filter = cyme::profiler::DeviceFilter {
-            no_exclude_root_hub: true,
+            include_root_hubs: true,
             ..cyme::profiler::DeviceFilter::from(vec![
                 cyme::profiler::Filter::new_with_name("Black Magic".into(), false),
                 cyme::profiler::Filter::new_with_name("J-Link".into(), false),
@@ -195,7 +195,7 @@ fn test_list_filtering() {
                 ..Default::default()
             }],
             exclude_filters: vec![cyme::profiler::Filter::new_with_name("Mouse".into(), false)],
-            no_exclude_root_hub: true,
+            include_root_hubs: true,
             ..Default::default()
         };
         comp_sp.into_flattened();
@@ -222,7 +222,7 @@ fn test_list_filtering() {
     {
         let mut comp_sp = common::sp_data_from_libusb_linux();
         let filter = cyme::profiler::DeviceFilter {
-            no_exclude_root_hub: true,
+            include_root_hubs: true,
             ..cyme::profiler::DeviceFilter::from(vec![
                 cyme::profiler::Filter {
                     vid: Some(0x203a),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -43,7 +43,7 @@ fn test_list_filtering() {
     let env = common::TestEnv::new();
 
     let mut comp_sp = common::sp_data_from_libusb_linux();
-    let filter = cyme::profiler::FilterGroup {
+    let filter = cyme::profiler::DeviceFilter {
         no_exclude_root_hub: true,
         ..cyme::profiler::Filter {
             name: Some("Black Magic".into()),
@@ -90,7 +90,7 @@ fn test_list_filtering() {
     );
 
     let mut comp_sp = common::sp_data_from_libusb_linux();
-    let mut filter = cyme::profiler::FilterGroup {
+    let mut filter = cyme::profiler::DeviceFilter {
         no_exclude_root_hub: true,
         ..cyme::profiler::Filter {
             bus: Some(2),
@@ -154,7 +154,7 @@ fn test_tree_filtering() {
     let env = common::TestEnv::new();
 
     let mut comp_sp = common::sp_data_from_libusb_linux();
-    let filter = cyme::profiler::FilterGroup::from(cyme::profiler::Filter {
+    let filter = cyme::profiler::DeviceFilter::from(cyme::profiler::Filter {
         name: Some("Black Magic".into()),
         ..Default::default()
     });

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -43,10 +43,13 @@ fn test_list_filtering() {
     let env = common::TestEnv::new();
 
     let mut comp_sp = common::sp_data_from_libusb_linux();
-    let filter = cyme::profiler::Filter {
-        name: Some("Black Magic".into()),
+    let filter = cyme::profiler::FilterGroup {
         no_exclude_root_hub: true,
-        ..Default::default()
+        ..cyme::profiler::Filter {
+            name: Some("Black Magic".into()),
+            ..Default::default()
+        }
+        .into()
     };
     comp_sp.into_flattened();
     let mut devices = comp_sp.flattened_devices();
@@ -87,10 +90,13 @@ fn test_list_filtering() {
     );
 
     let mut comp_sp = common::sp_data_from_libusb_linux();
-    let mut filter = cyme::profiler::Filter {
-        bus: Some(2),
+    let mut filter = cyme::profiler::FilterGroup {
         no_exclude_root_hub: true,
-        ..Default::default()
+        ..cyme::profiler::Filter {
+            bus: Some(2),
+            ..Default::default()
+        }
+        .into()
     };
     comp_sp.into_flattened();
     let mut devices = comp_sp.flattened_devices();
@@ -109,7 +115,9 @@ fn test_list_filtering() {
         &["--json", "--show", "f"],
     );
 
-    filter.number = Some(23);
+    if let Some(f) = filter.filters.first_mut() {
+        f.number = Some(23);
+    }
     filter.retain_flattened_devices_ref(&mut devices);
     let comp = serde_json::to_string_pretty(&devices).unwrap();
 
@@ -146,10 +154,10 @@ fn test_tree_filtering() {
     let env = common::TestEnv::new();
 
     let mut comp_sp = common::sp_data_from_libusb_linux();
-    let filter = cyme::profiler::Filter {
+    let filter = cyme::profiler::FilterGroup::from(cyme::profiler::Filter {
         name: Some("Black Magic".into()),
         ..Default::default()
-    };
+    });
     filter.retain_buses(&mut comp_sp.buses);
     let comp = serde_json::to_string_pretty(&comp_sp).unwrap();
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -132,6 +132,130 @@ fn test_list_filtering() {
         Some(common::CYME_LIBUSB_LINUX_TREE_DUMP),
         &["--json", "--show", "blah"],
     );
+
+    // Multiple --vidpid args are OR'd: Black Magic (1d50:6018) OR J-Link (1366:1050)
+    {
+        let mut comp_sp = common::sp_data_from_libusb_linux();
+        let filter = cyme::profiler::DeviceFilter {
+            no_exclude_root_hub: true,
+            ..cyme::profiler::DeviceFilter::from(vec![
+                cyme::profiler::Filter::new_with_vid_pid(0x1d50, 0x6018),
+                cyme::profiler::Filter::new_with_vid_pid(0x1366, 0x1050),
+            ])
+        };
+        comp_sp.into_flattened();
+        let mut devices = comp_sp.flattened_devices();
+        filter.retain_flattened_devices_ref(&mut devices);
+        let comp = serde_json::to_string_pretty(&devices).unwrap();
+
+        env.assert_output(
+            Some(common::CYME_LIBUSB_LINUX_TREE_DUMP),
+            &["--json", "--vidpid", "1d50:6018", "--vidpid", "1366:1050"],
+            &comp,
+            false,
+        );
+    }
+
+    // Multiple --filter-name args are OR'd
+    {
+        let mut comp_sp = common::sp_data_from_libusb_linux();
+        let filter = cyme::profiler::DeviceFilter {
+            no_exclude_root_hub: true,
+            ..cyme::profiler::DeviceFilter::from(vec![
+                cyme::profiler::Filter::new_with_name("Black Magic".into(), false),
+                cyme::profiler::Filter::new_with_name("J-Link".into(), false),
+            ])
+        };
+        comp_sp.into_flattened();
+        let mut devices = comp_sp.flattened_devices();
+        filter.retain_flattened_devices_ref(&mut devices);
+        let comp = serde_json::to_string_pretty(&devices).unwrap();
+
+        env.assert_output(
+            Some(common::CYME_LIBUSB_LINUX_TREE_DUMP),
+            &[
+                "--json",
+                "--filter-name",
+                "Black Magic",
+                "--filter-name",
+                "J-Link",
+            ],
+            &comp,
+            false,
+        );
+    }
+
+    // --filter-exclude removes matching devices from the inclusion set
+    // --vidpid 203a includes all three Virtual devices; --filter-exclude name=Mouse removes one
+    {
+        let mut comp_sp = common::sp_data_from_libusb_linux();
+        let filter = cyme::profiler::DeviceFilter {
+            filters: vec![cyme::profiler::Filter {
+                vid: Some(0x203a),
+                ..Default::default()
+            }],
+            exclude_filters: vec![cyme::profiler::Filter::new_with_name("Mouse".into(), false)],
+            no_exclude_root_hub: true,
+            ..Default::default()
+        };
+        comp_sp.into_flattened();
+        let mut devices = comp_sp.flattened_devices();
+        filter.retain_flattened_devices_ref(&mut devices);
+        let comp = serde_json::to_string_pretty(&devices).unwrap();
+
+        env.assert_output(
+            Some(common::CYME_LIBUSB_LINUX_TREE_DUMP),
+            &[
+                "--json",
+                "--vidpid",
+                "203a",
+                "--filter-exclude",
+                "name=Mouse",
+            ],
+            &comp,
+            false,
+        );
+    }
+
+    // Cross-product: two vidpids × one name produces two Filters (AND within each).
+    // J-Link (1366) does not contain "Virtual" so only the 203a devices pass.
+    {
+        let mut comp_sp = common::sp_data_from_libusb_linux();
+        let filter = cyme::profiler::DeviceFilter {
+            no_exclude_root_hub: true,
+            ..cyme::profiler::DeviceFilter::from(vec![
+                cyme::profiler::Filter {
+                    vid: Some(0x203a),
+                    name: Some("Virtual".into()),
+                    ..Default::default()
+                },
+                cyme::profiler::Filter {
+                    vid: Some(0x1366),
+                    name: Some("Virtual".into()),
+                    ..Default::default()
+                },
+            ])
+        };
+        comp_sp.into_flattened();
+        let mut devices = comp_sp.flattened_devices();
+        filter.retain_flattened_devices_ref(&mut devices);
+        let comp = serde_json::to_string_pretty(&devices).unwrap();
+
+        env.assert_output(
+            Some(common::CYME_LIBUSB_LINUX_TREE_DUMP),
+            &[
+                "--json",
+                "--vidpid",
+                "203a",
+                "--vidpid",
+                "1366",
+                "--filter-name",
+                "Virtual",
+            ],
+            &comp,
+            false,
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Inspired by #109.

Expands the profiler filtering to allow multiple filters and inverted filtering; exclude devices matching the filters.

Achieved by creating a new `DeviceFilter` type that is a container for the `Filter`. Most API replaces the passed `Filter` with this new `DeviceFilter`.

It contains the previous structural settings that were in the Filter and creates a sort of filtering spec.

* cli: accepts Vec of all --filter-xx Fields. Same args will be Or via unique `Filter`, combinational will be fields in `Filter` (And).
* cli: new `--filter-exclude KEY=VALUE` creates invert of filter args but without arg pollution.
* config: ~~now has filter key that takes array of `DeviceFilter`. Useful
  for default excludes. Will create example config.~~ Has a `filter-include` and `filter-exclude` that takes a `FilterEntry` for ergonomic solution that combines previous `hide-buses` and `hide-hubs` into filter. Reference config in 'doc/cyme_example_filter_config.json'. 

I considered adding a `FilterOp` to control And, Or, Not of the `Vec<Filters>` but realised that fields within `Filters` are always AND (vidpid AND name) with `Filter` Or `Filter` providing vidpid OR vidpid - one would never want vidpid AND vidpid or of the same `Filter` fields since no `Device` would have two vidpid or two base class or two names.

Would need a major release due to crate lib API changes to `Filter`. Use is mostly replaced by contained within `FilterGroup`.