### PR TITLE
Add option to mute hubs

### DIFF
--- a/doc/_cyme
+++ b/doc/_cyme
@@ -218,6 +218,7 @@ replace\:"Mask by replacing length with random chars"))' \
 '--filter-post[Filter devices after profiling rather than during]' \
 '*-z[Turn debugging information on. Alternatively can use RUST_LOG env\: INFO, DEBUG, TRACE]' \
 '*--debug[Turn debugging information on. Alternatively can use RUST_LOG env\: INFO, DEBUG, TRACE]' \
+'--mute-hubs[Apply muted colour to hub device lines instead of per-block colours]' \
 '--gen[Generate cli completions and man page]' \
 '--system-profiler[Use the system_profiler command on macOS to get USB data]' \
 '-h[Print help (see more with '\''--help'\'')]' \

--- a/doc/_cyme.ps1
+++ b/doc/_cyme.ps1
@@ -71,6 +71,7 @@ Register-ArgumentCompleter -Native -CommandName 'cyme' -ScriptBlock {
             [CompletionResult]::new('--filter-post', '--filter-post', [CompletionResultType]::ParameterName, 'Filter devices after profiling rather than during')
             [CompletionResult]::new('-z', '-z', [CompletionResultType]::ParameterName, 'Turn debugging information on. Alternatively can use RUST_LOG env: INFO, DEBUG, TRACE')
             [CompletionResult]::new('--debug', '--debug', [CompletionResultType]::ParameterName, 'Turn debugging information on. Alternatively can use RUST_LOG env: INFO, DEBUG, TRACE')
+            [CompletionResult]::new('--mute-hubs', '--mute-hubs', [CompletionResultType]::ParameterName, 'Apply muted colour to hub device lines instead of per-block colours')
             [CompletionResult]::new('--gen', '--gen', [CompletionResultType]::ParameterName, 'Generate cli completions and man page')
             [CompletionResult]::new('--system-profiler', '--system-profiler', [CompletionResultType]::ParameterName, 'Use the system_profiler command on macOS to get USB data')
             [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help (see more with ''--help'')')

--- a/doc/cyme.1
+++ b/doc/cyme.1
@@ -4,7 +4,7 @@
 .SH NAME
 cyme \- List system USB buses and devices. A modern cross\-platform lsusb
 .SH SYNOPSIS
-\fBcyme\fR [\fB\-l\fR|\fB\-\-lsusb\fR] [\fB\-t\fR|\fB\-\-tree\fR] [\fB\-d\fR|\fB\-\-vidpid\fR] [\fB\-s\fR|\fB\-\-show\fR] [\fB\-D\fR|\fB\-\-device\fR] [\fB\-\-filter\-name\fR] [\fB\-\-filter\-serial\fR] [\fB\-\-filter\-class\fR] [\fB\-\-filter\-exclude\fR] [\fB\-v\fR|\fB\-\-verbose\fR]... [\fB\-b\fR|\fB\-\-blocks\fR] [\fB\-\-bus\-blocks\fR] [\fB\-\-config\-blocks\fR] [\fB\-\-interface\-blocks\fR] [\fB\-\-endpoint\-blocks\fR] [\fB\-\-block\-operation\fR] [\fB\-m\fR|\fB\-\-more\fR] [\fB\-\-sort\-devices\fR] [\fB\-\-sort\-buses\fR] [\fB\-\-group\-devices\fR] [\fB\-\-hide\-buses\fR] [\fB\-\-hide\-hubs\fR] [\fB\-\-list\-root\-hubs\fR] [\fB\-\-decimal\fR] [\fB\-\-no\-padding\fR] [\fB\-\-color\fR] [\fB\-\-encoding\fR] [\fB\-\-icon\fR] [\fB\-\-headings\fR] [\fB\-\-json\fR] [\fB\-\-from\-json\fR] [\fB\-F\fR|\fB\-\-force\-libusb\fR] [\fB\-c\fR|\fB\-\-config\fR] [\fB\-z\fR|\fB\-\-debug\fR]... [\fB\-\-mask\-serials\fR] [\fB\-\-system\-profiler\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIsubcommands\fR]
+\fBcyme\fR [\fB\-l\fR|\fB\-\-lsusb\fR] [\fB\-t\fR|\fB\-\-tree\fR] [\fB\-d\fR|\fB\-\-vidpid\fR] [\fB\-s\fR|\fB\-\-show\fR] [\fB\-D\fR|\fB\-\-device\fR] [\fB\-\-filter\-name\fR] [\fB\-\-filter\-serial\fR] [\fB\-\-filter\-class\fR] [\fB\-\-filter\-exclude\fR] [\fB\-v\fR|\fB\-\-verbose\fR]... [\fB\-b\fR|\fB\-\-blocks\fR] [\fB\-\-bus\-blocks\fR] [\fB\-\-config\-blocks\fR] [\fB\-\-interface\-blocks\fR] [\fB\-\-endpoint\-blocks\fR] [\fB\-\-block\-operation\fR] [\fB\-m\fR|\fB\-\-more\fR] [\fB\-\-sort\-devices\fR] [\fB\-\-sort\-buses\fR] [\fB\-\-group\-devices\fR] [\fB\-\-hide\-buses\fR] [\fB\-\-hide\-hubs\fR] [\fB\-\-list\-root\-hubs\fR] [\fB\-\-decimal\fR] [\fB\-\-no\-padding\fR] [\fB\-\-color\fR] [\fB\-\-encoding\fR] [\fB\-\-icon\fR] [\fB\-\-headings\fR] [\fB\-\-json\fR] [\fB\-\-from\-json\fR] [\fB\-F\fR|\fB\-\-force\-libusb\fR] [\fB\-c\fR|\fB\-\-config\fR] [\fB\-z\fR|\fB\-\-debug\fR]... [\fB\-\-mask\-serials\fR] [\fB\-\-mute\-hubs\fR] [\fB\-\-system\-profiler\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIsubcommands\fR]
 .SH DESCRIPTION
 List system USB buses and devices. A modern cross\-platform lsusb
 .SH OPTIONS
@@ -475,6 +475,9 @@ scramble: Mask by randomising existing chars
 .IP \(bu 2
 replace: Mask by replacing length with random chars
 .RE
+.TP
+\fB\-\-mute\-hubs\fR
+Apply muted colour to hub device lines instead of per\-block colours
 .TP
 \fB\-\-system\-profiler\fR
 Use the system_profiler command on macOS to get USB data

--- a/doc/cyme.bash
+++ b/doc/cyme.bash
@@ -35,7 +35,7 @@ _cyme() {
 
     case "${cmd}" in
         cyme)
-            opts="-l -t -d -s -D -v -b -m -F -c -z -h -V --lsusb --tree --vidpid --show --device --filter-name --filter-serial --filter-class --filter-exclude --verbose --blocks --bus-blocks --config-blocks --interface-blocks --endpoint-blocks --block-operation --more --sort-devices --sort-buses --group-devices --hide-buses --hide-hubs --list-root-hubs --decimal --no-padding --color --no-color --encoding --ascii --no-icons --icon --headings --json --from-json --force-libusb --config --filter-post --debug --mask-serials --gen --system-profiler --help --version watch help"
+            opts="-l -t -d -s -D -v -b -m -F -c -z -h -V --lsusb --tree --vidpid --show --device --filter-name --filter-serial --filter-class --filter-exclude --verbose --blocks --bus-blocks --config-blocks --interface-blocks --endpoint-blocks --block-operation --more --sort-devices --sort-buses --group-devices --hide-buses --hide-hubs --list-root-hubs --decimal --no-padding --color --no-color --encoding --ascii --no-icons --icon --headings --json --from-json --force-libusb --config --filter-post --debug --mask-serials --mute-hubs --gen --system-profiler --help --version watch help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/doc/cyme.fish
+++ b/doc/cyme.fish
@@ -1,6 +1,6 @@
 # Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
 function __fish_cyme_global_optspecs
-	string join \n l/lsusb t/tree d/vidpid= s/show= D/device= filter-name= filter-serial= filter-class= filter-exclude= v/verbose b/blocks= bus-blocks= config-blocks= interface-blocks= endpoint-blocks= block-operation= m/more sort-devices= sort-buses group-devices= hide-buses hide-hubs list-root-hubs decimal no-padding color= no-color encoding= ascii no-icons icon= headings json from-json= F/force-libusb c/config= filter-post z/debug mask-serials= gen system-profiler h/help V/version
+	string join \n l/lsusb t/tree d/vidpid= s/show= D/device= filter-name= filter-serial= filter-class= filter-exclude= v/verbose b/blocks= bus-blocks= config-blocks= interface-blocks= endpoint-blocks= block-operation= m/more sort-devices= sort-buses group-devices= hide-buses hide-hubs list-root-hubs decimal no-padding color= no-color encoding= ascii no-icons icon= headings json from-json= F/force-libusb c/config= filter-post z/debug mask-serials= mute-hubs gen system-profiler h/help V/version
 end
 
 function __fish_cyme_needs_command
@@ -178,6 +178,7 @@ complete -c cyme -n "__fish_cyme_needs_command" -l json -d 'Output as json forma
 complete -c cyme -n "__fish_cyme_needs_command" -s F -l force-libusb -d 'Force pure libusb profiler on macOS rather than combining system_profiler output'
 complete -c cyme -n "__fish_cyme_needs_command" -l filter-post -d 'Filter devices after profiling rather than during'
 complete -c cyme -n "__fish_cyme_needs_command" -s z -l debug -d 'Turn debugging information on. Alternatively can use RUST_LOG env: INFO, DEBUG, TRACE'
+complete -c cyme -n "__fish_cyme_needs_command" -l mute-hubs -d 'Apply muted colour to hub device lines instead of per-block colours'
 complete -c cyme -n "__fish_cyme_needs_command" -l gen -d 'Generate cli completions and man page'
 complete -c cyme -n "__fish_cyme_needs_command" -l system-profiler -d 'Use the system_profiler command on macOS to get USB data'
 complete -c cyme -n "__fish_cyme_needs_command" -s h -l help -d 'Print help (see more with \'--help\')'

--- a/doc/cyme_example_config.json
+++ b/doc/cyme_example_config.json
@@ -49,7 +49,8 @@
     "tree_configuration_terminator": "bright black",
     "tree_interface_terminator": "bright black",
     "tree_endpoint_in": "yellow",
-    "tree_endpoint_out": "magenta"
+    "tree_endpoint_out": "magenta",
+    "muted": "bright black"
   },
   "blocks": [
     "bus-number",
@@ -116,5 +117,6 @@
   "json": false,
   "print-non-critical-profiler-stderr": false,
   "filter-include": [],
-  "filter-exclude": []
+  "filter-exclude": [],
+  "mute-hubs": false
 }

--- a/doc/cyme_example_filter_config.json
+++ b/doc/cyme_example_filter_config.json
@@ -27,7 +27,8 @@
     "tree_configuration_terminator": "bright black",
     "tree_interface_terminator": "bright black",
     "tree_endpoint_in": "yellow",
-    "tree_endpoint_out": "magenta"
+    "tree_endpoint_out": "magenta",
+    "muted": "bright black"
   },
   "blocks": null,
   "bus-blocks": null,
@@ -90,5 +91,6 @@
     {
       "vidpid": "1d6b:0002"
     }
-  ]
+  ],
+  "mute-hubs": false
 }

--- a/src/colour.rs
+++ b/src/colour.rs
@@ -177,6 +177,13 @@ pub struct ColourTheme {
         deserialize_with = "deserialize_option_color_from_string"
     )]
     pub tree_endpoint_out: Option<Color>,
+    /// Colour used when muting a line, e.g. for hub devices with mute-hubs
+    #[serde(
+        default,
+        serialize_with = "color_serializer",
+        deserialize_with = "deserialize_option_color_from_string"
+    )]
+    pub muted: Option<Color>,
 }
 
 fn deserialize_option_color_from_string<'de, D>(deserializer: D) -> Result<Option<Color>, D::Error>
@@ -344,6 +351,7 @@ impl ColourTheme {
             tree_interface_terminator: Some(Color::BrightBlack),
             tree_endpoint_in: Some(Color::Yellow),
             tree_endpoint_out: Some(Color::Magenta),
+            muted: Some(Color::BrightBlack),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -98,6 +98,8 @@ pub struct Config {
     /// Exclusion filters, OR'd together. Devices matching any entry are hidden even if
     /// they passed an inclusion filter.
     pub filter_exclude: Vec<crate::profiler::FilterEntry>,
+    /// Apply muted colour to hub device lines instead of per-block colours
+    pub mute_hubs: bool,
 }
 
 impl Config {
@@ -306,6 +308,7 @@ impl Config {
         self.ascii = matches!(settings.encoding, display::Encoding::Ascii);
         self.verbose = settings.verbosity;
         self.json = settings.json;
+        self.mute_hubs = settings.mute_hubs;
     }
 
     /// Returns a [`display::PrintSettings`] based on the config
@@ -365,6 +368,7 @@ impl Config {
             colours,
             verbosity: self.verbose,
             json: self.json,
+            mute_hubs: self.mute_hubs,
             ..Default::default()
         }
     }
@@ -480,5 +484,13 @@ mod tests {
         assert!(
             serde_json::from_str::<Config>(r#"{"filter-include": [{"vidpid": "gggg"}]}"#).is_err()
         );
+    }
+
+    #[test]
+    fn test_deserialize_colors_alias() {
+        let raw = r#"{"colors": {"name": "red", "muted": "blue"}}"#;
+        let c: Config = serde_json::from_str(raw).unwrap();
+        assert_eq!(c.colours.name, Some(Color::Red));
+        assert_eq!(c.colours.muted, Some(Color::Blue));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,6 +25,7 @@ pub struct Config {
     /// User supplied [`crate::icon::IconTheme`] - will merge with default
     pub icons: icon::IconTheme,
     /// User supplied [`crate::colour::ColourTheme`] - overrides default
+    #[serde(alias = "colors")]
     pub colours: colour::ColourTheme,
     /// Default [`crate::display::DeviceBlocks`] to use for displaying devices
     pub blocks: Option<Vec<display::DeviceBlocks>>,
@@ -391,6 +392,7 @@ impl From<&Config> for display::PrintSettings {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use colored::*;
 
     #[test]
     #[cfg(feature = "regex_icon")]

--- a/src/display.rs
+++ b/src/display.rs
@@ -20,7 +20,7 @@ use crate::icon;
 use crate::profiler::{Bus, Device, DeviceFilter, SystemProfile};
 use crate::types::NumericalUnit;
 use crate::usb::{
-    path::ConfigurationPath, path::DevicePath, path::EndpointPath, path::PortPath,
+    path::ConfigurationPath, path::DevicePath, path::EndpointPath, path::PortPath, BaseClass,
     ConfigAttributes, Configuration, DeviceExtra, Direction, Endpoint, Interface,
 };
 
@@ -2153,6 +2153,8 @@ pub struct PrintSettings {
     pub color_when: ColorWhen,
     /// Printing in watch mode
     pub print_mode: PrintMode,
+    /// Apply muted colour to hub device lines instead of per-block colours
+    pub mute_hubs: bool,
 }
 
 /// Converts a HashSet of [`ConfigAttributes`] a String of nerd icons
@@ -2315,6 +2317,18 @@ pub fn has_valid_icons<B: BlockEnum, T>(
     })
 }
 
+/// Controls per-line colour overrides applied by [`render_value`]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum LineStyle {
+    /// Normal per-block colouring
+    #[default]
+    Normal,
+    /// Dimmed white — used for disconnected devices
+    Dimmed,
+    /// Uniform muted colour — used to de-emphasise a line
+    Muted,
+}
+
 /// Formats each [`Block`] value shown from a device `d`
 pub fn render_value<B: BlockEnum, T>(
     d: &T,
@@ -2322,7 +2336,7 @@ pub fn render_value<B: BlockEnum, T>(
     pad: &HashMap<B, usize>,
     settings: &PrintSettings,
     max_string_length: Option<usize>,
-    dimmed: bool,
+    line_style: LineStyle,
 ) -> Vec<String> {
     let mut ret = Vec::new();
     for b in blocks {
@@ -2334,13 +2348,14 @@ pub fn render_value<B: BlockEnum, T>(
                 }
             }
             match &settings.colours {
-                Some(c) => {
-                    if dimmed {
-                        ret.push(format!("{}", string.dimmed().white()))
-                    } else {
-                        ret.push(format!("{}", b.colour(&string, c)))
-                    }
-                }
+                Some(c) => match line_style {
+                    LineStyle::Dimmed => ret.push(format!("{}", string.dimmed().white())),
+                    LineStyle::Muted => ret.push(format!(
+                        "{}",
+                        c.muted.map_or(string.normal(), |hc| string.color(hc))
+                    )),
+                    LineStyle::Normal => ret.push(format!("{}", b.colour(&string, c))),
+                },
                 None => ret.push(string.to_string()),
             };
         }
@@ -2661,7 +2676,7 @@ impl<W: Write> DisplayWriter<W> {
         blocks: &[EndpointBlocks],
         settings: &PrintSettings,
         tree: &TreeData,
-        dimmed: bool,
+        line_style: LineStyle,
     ) {
         let endpoints = &interface.endpoints;
         let device_path = interface.device_path();
@@ -2777,7 +2792,7 @@ impl<W: Write> DisplayWriter<W> {
                         &pad,
                         settings,
                         max_variable_string_len,
-                        dimmed,
+                        line_style,
                     )
                     .join(" "),
                     line_item,
@@ -2803,7 +2818,7 @@ impl<W: Write> DisplayWriter<W> {
                             &pad,
                             settings,
                             max_variable_string_len,
-                            dimmed
+                            line_style,
                         )
                         .join(" "),
                         spaces = (EndpointBlocks::INSET * LIST_INSET_SPACES) as usize
@@ -2822,7 +2837,7 @@ impl<W: Write> DisplayWriter<W> {
         blocks: (&Vec<InterfaceBlocks>, &Vec<EndpointBlocks>),
         settings: &PrintSettings,
         tree: &TreeData,
-        dimmed: bool,
+        line_style: LineStyle,
     ) {
         let mut pad = if !settings.no_padding {
             let interfaces: Vec<&Interface> = interfaces.iter().collect();
@@ -2924,7 +2939,7 @@ impl<W: Write> DisplayWriter<W> {
                         &pad,
                         settings,
                         max_variable_string_len,
-                        dimmed,
+                        line_style,
                     )
                     .join(" "),
                     line_item,
@@ -2950,7 +2965,7 @@ impl<W: Write> DisplayWriter<W> {
                             &pad,
                             settings,
                             max_variable_string_len,
-                            dimmed
+                            line_style,
                         )
                         .join(" "),
                         spaces = (InterfaceBlocks::INSET * LIST_INSET_SPACES) as usize
@@ -2967,7 +2982,7 @@ impl<W: Write> DisplayWriter<W> {
                     blocks.1,
                     settings,
                     &generate_tree_data(tree, interface.endpoints.len(), i, settings),
-                    dimmed,
+                    line_style,
                 );
             }
         }
@@ -3080,6 +3095,11 @@ impl<W: Write> DisplayWriter<W> {
                 // render and print tree if doing it
                 self.print(format!("{prefix}{terminator} ")).unwrap();
 
+                let ls = if device.is_disconnected() {
+                    LineStyle::Dimmed
+                } else {
+                    LineStyle::Normal
+                };
                 self.println(
                     render_value(
                         config,
@@ -3087,7 +3107,7 @@ impl<W: Write> DisplayWriter<W> {
                         &pad,
                         settings,
                         max_variable_string_len,
-                        device.is_disconnected(),
+                        ls,
                     )
                     .join(" "),
                     line_item,
@@ -3103,6 +3123,11 @@ impl<W: Write> DisplayWriter<W> {
                     .unwrap();
                 }
 
+                let ls = if device.is_disconnected() {
+                    LineStyle::Dimmed
+                } else {
+                    LineStyle::Normal
+                };
                 self.println(
                     format!(
                         "{:spaces$}{}",
@@ -3113,7 +3138,7 @@ impl<W: Write> DisplayWriter<W> {
                             &pad,
                             settings,
                             max_variable_string_len,
-                            device.is_disconnected()
+                            ls,
                         )
                         .join(" "),
                         spaces = (ConfigurationBlocks::INSET * LIST_INSET_SPACES) as usize
@@ -3125,12 +3150,17 @@ impl<W: Write> DisplayWriter<W> {
 
             // print the interfaces
             if settings.verbosity >= 2 || config.is_expanded() {
+                let ls = if device.is_disconnected() {
+                    LineStyle::Dimmed
+                } else {
+                    LineStyle::Normal
+                };
                 self.print_interfaces(
                     &config.interfaces,
                     ((blocks.1), (blocks.2)),
                     settings,
                     &generate_tree_data(tree, config.interfaces.len(), i, settings),
-                    device.is_disconnected(),
+                    ls,
                 );
             }
         }
@@ -3232,13 +3262,20 @@ impl<W: Write> DisplayWriter<W> {
             }
 
             // print the device
+            let line_style = if device.is_disconnected() {
+                LineStyle::Dimmed
+            } else if settings.mute_hubs && device.class == Some(BaseClass::Hub) {
+                LineStyle::Muted
+            } else {
+                LineStyle::Normal
+            };
             let device_string = render_value(
                 device,
                 db,
                 &padding,
                 settings,
                 max_variable_string_len,
-                device.is_disconnected(),
+                line_style,
             )
             .join(" ");
             self.println(&device_string, LineItem::Device(device.port_path()))
@@ -3404,7 +3441,15 @@ impl<W: Write> DisplayWriter<W> {
                     .unwrap();
             }
             self.println(
-                render_value(bus, &bb, &pad, settings, max_variable_string_len, false).join(" "),
+                render_value(
+                    bus,
+                    &bb,
+                    &pad,
+                    settings,
+                    max_variable_string_len,
+                    LineStyle::Normal,
+                )
+                .join(" "),
                 LineItem::Bus(i),
             )
             .unwrap();
@@ -3504,6 +3549,13 @@ impl<W: Write> DisplayWriter<W> {
         }
 
         for (i, device) in devices.iter().enumerate() {
+            let line_style = if device.is_disconnected() {
+                LineStyle::Dimmed
+            } else if settings.mute_hubs && device.class == Some(BaseClass::Hub) {
+                LineStyle::Muted
+            } else {
+                LineStyle::Normal
+            };
             println!(
                 "{}",
                 render_value(
@@ -3512,7 +3564,7 @@ impl<W: Write> DisplayWriter<W> {
                     &pad,
                     settings,
                     max_variable_string_len,
-                    device.is_disconnected()
+                    line_style,
                 )
                 .join(" ")
             );
@@ -3593,7 +3645,15 @@ impl<W: Write> DisplayWriter<W> {
                     .unwrap();
             }
             self.println(
-                render_value(bus, &bb, &pad, settings, max_variable_string_len, false).join(" "),
+                render_value(
+                    bus,
+                    &bb,
+                    &pad,
+                    settings,
+                    max_variable_string_len,
+                    LineStyle::Normal,
+                )
+                .join(" "),
                 LineItem::Bus(i),
             )
             .unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -219,6 +219,10 @@ struct Args {
     #[arg(long)]
     mask_serials: Option<display::MaskSerial>,
 
+    /// Apply muted colour to hub device lines instead of per-block colours
+    #[arg(long, default_value_t = false)]
+    mute_hubs: bool,
+
     /// Generate cli completions and man page
     #[cfg(feature = "cli_generate")]
     #[arg(long, hide = true, exclusive = true)]
@@ -306,6 +310,7 @@ fn merge_config(c: &mut Config, a: &Args) {
     if a.block_operation.is_some() {
         c.block_operation = a.block_operation;
     }
+    c.mute_hubs |= a.mute_hubs;
     c.sort_buses |= a.sort_buses;
     // take larger debug level
     c.verbose = c.verbose.max(a.verbose);


### PR DESCRIPTION
Effectively like commenting out hubs: strip block colouring (syntax) and colour with single color. The colour is configurable in the colour config but defaults to BrightBlack - 'gray' and same as tree so eyes can easily skip over the hubs.

Nicer than hide-hubs because the hubs are still there but just visually can be filtered.

I've made the muting generic so it can be potentially used for other features.

* arg: `-mute-hubs`
* config: `mute-hubs` key.
* config.colours: `muted` key for the colour to use when muting.
* PrintSettings: `mute_hubs` option.

Also added alias to `Config` because I notice I use colour (I’m British) but other places I use the US programming convention - including this PR!   

<img width="1677" height="427" alt="image" src="https://github.com/user-attachments/assets/1a7829ef-0ff4-46bf-8ceb-cfbc19cc9676" />
