### PR TITLE
display: icon for hubs on tree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,9 +70,13 @@ watch = ["crossterm", "futures-lite", "nusb", "cansi"] # watch mode
 bin = []
 default = ["native", "regex_icon", "watch", "bin"] # default native Rust USB (nusb, udevrs) with regex icon name lookup
 
+[lib]
+bench = false
+
 [[bin]]
 name = "cyme"
 path = "src/main.rs"
+bench = false
 
 [[bench]]
 name = "get"

--- a/doc/cyme_example_config.json
+++ b/doc/cyme_example_config.json
@@ -21,6 +21,7 @@
       "tree-device-terminator": "○",
       "tree-disconnected-terminator": "✕",
       "tree-edge": "├──",
+      "tree-hub-terminator": "⊛",
       "tree-interface-terminator": "◦",
       "tree-line": "│  "
     }

--- a/src/display.rs
+++ b/src/display.rs
@@ -3223,6 +3223,8 @@ impl<W: Write> DisplayWriter<W> {
 
                 let icon_terminator = if device.is_disconnected() {
                     icon::Icon::TreeDisconnectedTerminator
+                } else if device.class == Some(BaseClass::Hub) {
+                    icon::Icon::TreeHubTerminator
                 } else {
                     icon::Icon::TreeDeviceTerminator
                 };

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -59,6 +59,8 @@ pub enum Icon {
     TreeInterfaceTerminator,
     /// Icon printed at end of tree before disconnected device
     TreeDisconnectedTerminator,
+    /// Icon printed at end of tree before printing hub device
+    TreeHubTerminator,
     /// Icon for endpoint direction
     Endpoint(Direction),
     /// Icon for profiled state
@@ -95,6 +97,7 @@ impl FromStr for Icon {
                 "profiled" => Ok(Icon::Profiled),
                 "connected" => Ok(Icon::Connected),
                 "disconnected" => Ok(Icon::Disconnected),
+                "tree-hub-terminator" => Ok(Icon::TreeHubTerminator),
                 _ => Err(Error::new(
                     ErrorKind::Parsing,
                     "Invalid Icon enum name or valued enum without value",
@@ -240,6 +243,7 @@ pub static DEFAULT_UTF8_TREE: LazyLock<HashMap<Icon, &'static str>> = LazyLock::
         (Icon::TreeConfigurationTerminator, "\u{2022}"), // "•"
         (Icon::TreeInterfaceTerminator, "\u{25E6}"),     // "◦"
         (Icon::TreeDisconnectedTerminator, "\u{2715}"),  // "×"
+        (Icon::TreeHubTerminator, "\u{229b}"),           // "⊛"
         (Icon::Endpoint(Direction::In), "\u{2192}"),     // →
         (Icon::Endpoint(Direction::Out), "\u{2190}"),    // ←
     ])
@@ -257,6 +261,7 @@ pub static DEFAULT_ASCII_TREE: LazyLock<HashMap<Icon, &'static str>> = LazyLock:
         (Icon::TreeConfigurationTerminator, "o"),
         (Icon::TreeInterfaceTerminator, "."),
         (Icon::TreeDisconnectedTerminator, "X"),
+        (Icon::TreeHubTerminator, "*"),
         (Icon::Endpoint(Direction::In), ">"),
         (Icon::Endpoint(Direction::Out), "<"),
     ])


### PR DESCRIPTION
Adds a `TreeHubTerminator` to icons so that hub devices can have a different terminator icon.

Default is ⊛ so it’s not a massive change but helpful for visual processing.

Can be changed with icons.tree.tree-hub-terminator in config.

<img width="2420" height="586" alt="image" src="https://github.com/user-attachments/assets/e2b65447-447f-49d2-ad23-9ca3c00a026d" />
