### PR TITLE
fix class/protocol definitions for MCTP

### DIFF
--- a/src/usb.rs
+++ b/src/usb.rs
@@ -567,7 +567,7 @@ where
             (BaseClass::Audio, 0x02, 0x00) => ClassCode::AudioVideoDataVideo,
             (BaseClass::Audio, 0x03, 0x00) => ClassCode::AudioVideoDataAudio,
             (BaseClass::Mctp, 0x00, 0x01) => ClassCode::MctpManagementController,
-            (BaseClass::Mctp, 0x00, 0x02) => ClassCode::MctpHostInterfaceEndpoint,
+            (BaseClass::Mctp, 0x01, 0x01) => ClassCode::MctpHostInterfaceEndpoint,
             (BaseClass::Diagnostic, 0x01, 0x01) => ClassCode::Usb2ComplianceDevice,
             (BaseClass::Diagnostic, 0x02, 0x00) => ClassCode::DebugTargetVendorDefined,
             (BaseClass::Diagnostic, 0x02, 0x01) => ClassCode::GnuRemoteDebugCommandSet,


### PR DESCRIPTION
The current class code definition for MCTP host interface devices is incorrect. As per the defined class codes spec[1], the subclass should be 0x00/0x01 to indicate management controller/host devices, and protocol should be 0x01 to indicate MCTP version 1.

So, fix the host interface class code definition for the host interface.

There is currently no MCTP v2 spec (the DMTF MCTP-over-USB v1.1.0 spec[2] specfies protocol 0x02 as "reserved for MCTP 2.x", rather than defined) so leave protocol 0x02 absent for now.

[1]: https://usb.org/defined-class-codes#anchor_BaseClass14h
[2]: https://www.dmtf.org/sites/default/files/standards/documents/DSP0283_1.1.0.pdf